### PR TITLE
Config cleanup

### DIFF
--- a/admin/src/components/Initializer/index.js
+++ b/admin/src/components/Initializer/index.js
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
-import { useSupportedUIDs } from '../../hooks';
+import { usePluginConfig } from '../../hooks';
 import { pluginId } from '../../utils';
 
 const Initializer = ( { setPlugin } ) => {
-  const { uids, isLoading } = useSupportedUIDs();
+  const { isLoading } = usePluginConfig();
   const ref = useRef();
 
   ref.current = setPlugin;

--- a/admin/src/components/Initializer/index.js
+++ b/admin/src/components/Initializer/index.js
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-import { useDispatch } from 'react-redux';
 
 import { useSupportedUIDs } from '../../hooks';
 import { pluginId } from '../../utils';
@@ -12,10 +11,10 @@ const Initializer = ( { setPlugin } ) => {
   ref.current = setPlugin;
 
   useEffect( () => {
-    if ( ! isLoading && uids.length > 0 ) {
+    if ( ! isLoading ) {
       ref.current( pluginId );
     }
-  }, [ uids, isLoading ] );
+  }, [ isLoading ] );
 
   return null;
 };

--- a/admin/src/components/Injector/index.js
+++ b/admin/src/components/Injector/index.js
@@ -17,9 +17,9 @@ const Injector = () => {
   } = useCMEditViewDataManager();
   const { id } = useParams();
   const { uid } = allLayoutData.contentType;
-  const uids = useSelector( state => state[ `${pluginId}_config` ].uids );
+  const { contentTypes } = useSelector( state => state[ `${pluginId}_config` ].config );
 
-  const isSupportedType = uids.includes( uid );
+  const isSupportedType = contentTypes.includes( uid );
   const shouldRender = isSupportedType && ! isCreatingEntry;
 
   if ( ! shouldRender ) {

--- a/admin/src/constants.js
+++ b/admin/src/constants.js
@@ -3,4 +3,4 @@ import { pluginId } from './utils';
 export const PREVIEW_WINDOW_NAME = 'StrapiPreview';
 
 export const RESOLVE_DATA = `${pluginId}/resolve-data`;
-export const RESOLVE_UIDS = `${pluginId}/resolve-uids`;
+export const RESOLVE_CONFIG = `${pluginId}/resolve-config`;

--- a/admin/src/constants.js
+++ b/admin/src/constants.js
@@ -2,5 +2,5 @@ import { pluginId } from './utils';
 
 export const PREVIEW_WINDOW_NAME = 'StrapiPreview';
 
-export const RESOLVE_DATA = `${pluginId}/resolve-data`;
+export const RESOLVE_PREVIEW = `${pluginId}/resolve-data`;
 export const RESOLVE_CONFIG = `${pluginId}/resolve-config`;

--- a/admin/src/hooks/index.js
+++ b/admin/src/hooks/index.js
@@ -1,2 +1,2 @@
+export { default as usePluginConfig } from './use-plugin-config';
 export { default as usePreviewData } from './use-preview-data';
-export { default as useSupportedUIDs } from './use-supported-uids';

--- a/admin/src/hooks/use-plugin-config.js
+++ b/admin/src/hooks/use-plugin-config.js
@@ -2,15 +2,15 @@ import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { request, useNotification } from '@strapi/helper-plugin';
 
-import { RESOLVE_UIDS } from '../constants';
+import { RESOLVE_CONFIG } from '../constants';
 import { pluginId } from '../utils';
 
-const fetchUIDs = async ( toggleNotification ) => {
+const fetchConfig = async ( toggleNotification ) => {
   try {
-    const endpoint = `/${pluginId}/uids`;
+    const endpoint = `/${pluginId}/config`;
     const data = await request( endpoint, { method: 'GET' } );
 
-    return data?.uids ?? [];
+    return data?.config ?? {};
   } catch ( err ) {
     toggleNotification( {
       type: 'warning',
@@ -21,19 +21,19 @@ const fetchUIDs = async ( toggleNotification ) => {
   }
 };
 
-const useSupportedUIDs = () => {
+const usePluginConfig = () => {
   const dispatch = useDispatch();
   const toggleNotification = useNotification();
-  const uids = useSelector( state => state[ `${pluginId}_config` ].uids );
+  const config = useSelector( state => state[ `${pluginId}_config` ].config );
   const isLoading = useSelector( state => state[ `${pluginId}_config` ].isLoading );
 
   useEffect( () => {
-    fetchUIDs( toggleNotification ).then( data => {
-      dispatch( { type: RESOLVE_UIDS, data } );
+    fetchConfig( toggleNotification ).then( data => {
+      dispatch( { type: RESOLVE_CONFIG, data } );
     } );
   }, [ dispatch, toggleNotification ] );
 
-  return { uids, isLoading };
+  return { config, isLoading };
 };
 
-export default useSupportedUIDs;
+export default usePluginConfig;

--- a/admin/src/hooks/use-preview-data.js
+++ b/admin/src/hooks/use-preview-data.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { request, useNotification } from '@strapi/helper-plugin';
 
-import { RESOLVE_DATA } from '../constants';
+import { RESOLVE_PREVIEW } from '../constants';
 import { pluginId } from '../utils';
 
 const fetchData = async ( uid, id, toggleNotification ) => {
@@ -29,7 +29,7 @@ const usePreviewData = ( uid, id, fetchDependencies ) => {
 
   useEffect( () => {
     fetchData( uid, id, toggleNotification ).then( data => {
-      dispatch( { type: RESOLVE_DATA, data } );
+      dispatch( { type: RESOLVE_PREVIEW, data } );
     } );
   }, [ dispatch, toggleNotification, ...fetchDependencies ] );
 

--- a/admin/src/reducers/config.js
+++ b/admin/src/reducers/config.js
@@ -1,17 +1,19 @@
 import produce from 'immer';
 
-import { RESOLVE_UIDS } from '../constants';
+import { RESOLVE_CONFIG } from '../constants';
 
 const initialState = {
   isLoading: true,
-  uids: [],
+  config: {
+    contentTypes: [],
+  },
 };
 
 const configReducer = produce( ( state = initialState, action ) => {
   switch ( action.type ) {
-    case RESOLVE_UIDS: {
+    case RESOLVE_CONFIG: {
       state.isLoading = false;
-      state.uids = action.data;
+      state.config = action.data;
       break;
     }
 

--- a/admin/src/reducers/main.js
+++ b/admin/src/reducers/main.js
@@ -1,6 +1,6 @@
 import produce from 'immer';
 
-import { RESOLVE_DATA } from '../constants';
+import { RESOLVE_PREVIEW } from '../constants';
 
 const initialState = {
   isLoading: true,
@@ -9,7 +9,7 @@ const initialState = {
 
 const mainReducer = produce( ( state = initialState, action ) => {
   switch ( action.type ) {
-    case RESOLVE_DATA: {
+    case RESOLVE_PREVIEW: {
       state.isLoading = false;
       state.data = action.data;
       break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-preview-button",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A plugin for Strapi CMS that adds a preview button and live view button to the content manager edit view.",
   "license": "MIT",
   "strapi": {

--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -3,6 +3,16 @@
 const { getService, pluginId } = require( '../utils' );
 
 module.exports = {
+  async config( ctx ) {
+    const { contentTypes } = await getService( 'preview-button' ).getConfig();
+
+    const config = {
+      contentTypes: contentTypes.map( type => type.uid ),
+    };
+
+    ctx.send( { config } );
+  },
+
   async findOne( ctx ) {
     const { uid, id } = ctx.request.params;
 
@@ -33,13 +43,5 @@ module.exports = {
 
     // Return preview URLs.
     ctx.send( { urls } );
-  },
-
-  async getUIDs( ctx ) {
-    const { contentTypes } = await getService( 'preview-button' ).getConfig();
-    const uids = contentTypes.map( type => type.uid );
-
-    // Return supported UIDs.
-    ctx.send( { uids } );
   },
 };

--- a/server/routes/admin-api.js
+++ b/server/routes/admin-api.js
@@ -5,8 +5,8 @@ module.exports = {
   routes: [
     {
       method: 'GET',
-      path: '/uids',
-      handler: 'preview-button.getUIDs',
+      path: '/config',
+      handler: 'preview-button.config',
       config: {
         policies: [ 'admin::isAuthenticatedAdmin' ],
       },


### PR DESCRIPTION
## Included in this release

* Refactor everything that fetches and stores `uids` and instead work with a more generic config object.