### PR TITLE
Add condition to show preview button on SingleType

### DIFF
--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -25,9 +25,12 @@ module.exports = {
     const pluginService = await getService( 'preview-button' );
     const { contentTypes } = await pluginService.getConfig();
     const supportedType = contentTypes.find( type => type.uid === uid );
-    const entity = await strapi.query( uid ).findOne( {
-      where: { id },
-    } );
+    // Fetch only entity if id of Collection is undefined.
+    const entity = id != undefined ?
+      await strapi.query( uid ).findOne({}) :
+      await strapi.query( uid ).findOne({
+        where: { id },
+      } );
 
     // Raise warning if plugin is active but not properly configured with required env vars.
     if ( ! hasEnvVars ) {

--- a/server/services/preview-button.js
+++ b/server/services/preview-button.js
@@ -36,7 +36,8 @@ module.exports = ( { strapi } ) => ( {
     }
 
     draftUrl = `${draftUrl}?${qs.stringify( draftParams )}`;
-    publishedUrl = `${publishedUrl}/${entity[ targetField ]}`;
+    // Remove entity targetField if is a SingleType
+    publishedUrl = entity[ targetField ] ? `${publishedUrl}/${entity[ targetField ]}` : `${publishedUrl}`;
 
     return {
       draftUrl,


### PR DESCRIPTION
I noticed that the plugin did not show the preview button if it was configured with a uid of a single type and not a collection.
I think it is very useful to have the preview button configurable also as regards the single types, it allows you to have easier content management on Strapi.
The change I made has very little impact on the code, but it is definitely not perfect.
It would be better to have a separate route for single types and handle the call by passing only uid.
Thank you so much for the work you have done in building the plugin.