### PR TITLE
Support single types

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 * New button in content manager sidebar which links the user to a preview or live view of a frontend app view.
 * Customize which content types should use the preview button.
 * Customize endpoints for draft and published URLs.
+* Support collection and single types.
 
 ## <a id="installation"></a>💎 Installation
 ```bash
@@ -47,10 +48,10 @@ It is **not** required to enable `draftAndPublish` for content types using this 
 ### `contentTypes`
 An array of objects describing which content types should use the preview button.
 
-Each object in the array requires a `uid` and `targetField` prop. The field name "slug" is recommended for the `targetField` value because it represents the unique part of the URL path, but it is not required.
+Each object in the array requires a `uid` prop at minimum. If you are configuring a collection type, the `targetField` is also required but it is optional with single types. The field name "slug" is recommended for the `targetField` value because it represents the unique part of the URL path, but it is not required.
 
-#### Example
-Consider we have `Page` and `Post` content types, where each has a `uid` field named `slug` and entries created for each, with the slug values set to `my-page` and `my-post`.
+#### Collection type example
+Consider we have `Page` and `Post` content types, where each has a `uid` field named `slug` and entries created for each, with the slug values set to `my-page` and `my-post`. Here is the minimum required config.
 
 ```js
 module.exports = {
@@ -72,7 +73,7 @@ module.exports = {
 };
 ```
 
-In this example, our pages and posts will be routed differently in our frontend app. To help with this, each content type may include a `query` string object for the draft URL and a `basePath` for the published URL.
+In this example, our pages and posts will be routed differently in our frontend app. To help with this, props like `basePath` and `query` may be configured for variations between `draft` and `published` URLs.
 
 ```js
 module.exports = {
@@ -114,6 +115,44 @@ https://example.com/api/preview?slug=my-post&type=post&secret=YOURSECRET
 ```
 https://example.com/my-page
 https://example.com/blog/my-post
+```
+
+#### Single type example
+Consider we have an `About` single type to serve as our "About" page. Unlike collection types, we don't necessarily need an editable `targetField` with our model if we know for sure it will always be `/about`. You can still provide the `targetField` if you want to keep this value editable in Strapi.
+
+```js
+module.exports = {
+  'preview-button': {
+    enabled: true,
+    config: {
+      contentTypes: [
+        {
+          uid: 'api::about.about',
+          draft: {
+            query: {
+              slug: 'about',
+            },
+          },
+          published: {
+            basePath: 'about',
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+This configuration will result in the following preview URLs for `About`.
+
+##### Draft URL path
+```
+https://example.com/api/preview?slug=aboute&secret=YOURSECRET
+```
+
+##### Published URL path
+```
+https://example.com/about
 ```
 
 ## <a id="user-guide"></a>📘 User Guide

--- a/admin/src/hooks/use-preview-data.js
+++ b/admin/src/hooks/use-preview-data.js
@@ -7,7 +7,13 @@ import { pluginId } from '../utils';
 
 const fetchData = async ( uid, id, toggleNotification ) => {
   try {
-    const endpoint = `/${pluginId}/${uid}/${id}`;
+    let endpoint = `/${pluginId}/${uid}`;
+
+    // Optional ID to support single types.
+    if ( id ) {
+      endpoint = `${endpoint}/${id}`;
+    }
+
     const data = await request( endpoint, { method: 'GET' } );
 
     return data;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-preview-button",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "A plugin for Strapi CMS that adds a preview button and live view button to the content manager edit view.",
   "license": "MIT",
   "strapi": {

--- a/server/config.js
+++ b/server/config.js
@@ -16,16 +16,11 @@ module.exports = {
       throw new ValidationError( `Must define contentTypes as an array.` );
     }
 
-    // Validate each content type.
+    // Validate each content type object.
     config.contentTypes.forEach( entry => {
       // Required `uid` prop.
       if ( ! entry.uid ) {
         throw new ValidationError( `Missing uid for ${entry.uid}.` );
-      }
-
-      // Required `targetField` prop.
-      if ( ! entry.targetField ) {
-        throw new ValidationError( `Missing targetField for ${entry.uid}.` );
       }
     } );
   },

--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -25,6 +25,8 @@ module.exports = {
     const pluginService = getService( 'preview-button' );
     const { contentTypes } = await pluginService.getConfig();
     const supportedType = contentTypes.find( type => type.uid === uid );
+
+    // Collection types will find by the ID and single types do not.
     const findParams = id ? { where: { id } } : {};
     const entity = await strapi.query( uid ).findOne( findParams );
 

--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -22,12 +22,11 @@ module.exports = {
       process.env.STRAPI_PREVIEW_PUBLISHED_URL,
     ].every( val => val );
 
-    const pluginService = await getService( 'preview-button' );
+    const pluginService = getService( 'preview-button' );
     const { contentTypes } = await pluginService.getConfig();
     const supportedType = contentTypes.find( type => type.uid === uid );
-    const entity = await strapi.query( uid ).findOne( {
-      where: { id },
-    } );
+    const findParams = id ? { where: { id } } : {};
+    const entity = await strapi.query( uid ).findOne( findParams );
 
     // Raise warning if plugin is active but not properly configured with required env vars.
     if ( ! hasEnvVars ) {

--- a/server/routes/admin-api.js
+++ b/server/routes/admin-api.js
@@ -19,5 +19,13 @@ module.exports = {
         policies: [ 'admin::isAuthenticatedAdmin' ],
       },
     },
+    {
+      method: 'GET',
+      path: '/:uid',
+      handler: 'preview-button.findOne',
+      config: {
+        policies: [ 'admin::isAuthenticatedAdmin' ],
+      },
+    },
   ],
 };

--- a/server/utils/build-url.js
+++ b/server/utils/build-url.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const qs = require( 'qs' );
+
+const stripSlashes = str => str ? str.replace( /^\//, '' ).replace( /\/$/, '' ) : '';
+
+const buildUrl = ( baseUrl, basePath, slug, params ) => {
+  const sanitizedBaseUrl = stripSlashes( baseUrl );
+  const sanitizedBasePath = stripSlashes( basePath );
+  const query = qs.stringify( params, { addQueryPrefix: true } );
+  const url = [ sanitizedBaseUrl, sanitizedBasePath, slug ].filter( i => i ).join( '/' );
+
+  return `${url}${query}`;
+};
+
+module.exports = buildUrl;

--- a/server/utils/index.js
+++ b/server/utils/index.js
@@ -1,9 +1,11 @@
 'use strict';
 
 const getService = require( './get-service' );
+const buildUrl = require( './build-url' );
 const pluginId = require( './plugin-id' );
 
 module.exports = {
+  buildUrl,
   getService,
   pluginId,
 };


### PR DESCRIPTION
This release brings support for single types using the preview button and also refactors how config options are used to build more flexible URLs.