### PR TITLE
Added option to use different target fields based on draft or publish mode

### DIFF
--- a/server/services/preview-button.js
+++ b/server/services/preview-button.js
@@ -14,10 +14,12 @@ module.exports = ( { strapi } ) => ( {
   },
 
   getPreviewUrls( entity, contentType ) {
-    const { uid, targetField, publishedTargetField, draftTargetField, draft, published } = contentType;
+    const { uid, targetField, draft, published } = contentType;
 
-    const publishedTargetFieldValue = get( entity, publishedTargetField, null );
-    const draftTargetFieldValue = get( entity, draftTargetField, null );
+    const draftTargetField = get( draft, 'targetField', null );
+    const publishedTargetField = get( published, 'targetField', null );
+    const draftTargetFieldValue = get( entity, draftTargetField, targetField );
+    const publishedTargetFieldValue = get( entity, publishedTargetField, targetField );
 
     const publishedBasePath = get( published, 'basePath', null );
     const publishedQuery = get( published, 'query', {} );

--- a/server/services/preview-button.js
+++ b/server/services/preview-button.js
@@ -14,8 +14,11 @@ module.exports = ( { strapi } ) => ( {
   },
 
   getPreviewUrls( entity, contentType ) {
-    const { uid, targetField, draft, published } = contentType;
-    const targetFieldValue = get( entity, targetField, null );
+    const { uid, targetField, publishedTargetField, draftTargetField, draft, published } = contentType;
+
+    const publishedTargetFieldValue = get( entity, publishedTargetField, null );
+    const draftTargetFieldValue = get( entity, draftTargetField, null );
+
     const publishedBasePath = get( published, 'basePath', null );
     const publishedQuery = get( published, 'query', {} );
     const draftBasePath = get( draft, 'basePath', null );
@@ -27,8 +30,8 @@ module.exports = ( { strapi } ) => ( {
     // Optionally include the `targetField` value in the draft query params.
     // Only collection types truly require the `targetField`, while single types
     // can optionally use the `basePath` to help build the desired URL.
-    if ( targetField && targetFieldValue ) {
-      draftQuery[ targetField ] = targetFieldValue;
+    if ( draftTargetField && draftTargetFieldValue ) {
+      draftQuery[ draftTargetField ] = draftTargetFieldValue;
     }
 
     // Build final URLs.
@@ -42,7 +45,7 @@ module.exports = ( { strapi } ) => ( {
     const publishedUrl = buildUrl(
       process.env.STRAPI_PREVIEW_PUBLISHED_URL,
       publishedBasePath,
-      targetFieldValue,
+      publishedTargetFieldValue,
       publishedQuery
     );
 


### PR DESCRIPTION
Hello, nice?

Well, i`m working in a project that i have a really specificied necessity: use different target fields for publish and draft content types. I have this necessity because im using this plugin: https://market.strapi.io/plugins/@notum-cz-strapi-plugin-content-versioning that basiclly do what his name propose. For my user get the preview page based on **DRAFT** the content that he is seeing, I have to use the id property to know what page to show for my user, but if he is seeing the **PUBLISHED** page, i have to use the slug property because my url seems like this "https://domain/[slug]", not "https://domain/[id]".When a use the preview mode, I can use the id of my data to get the preview and than redirect to the page based on the slug, like this:

```
import StrapiAPI from "../../services/strapi";

export default async function preview(req, res) {
  if (req.query.secret !== process.env.STRAPI_PREVIEW_SECRET || !req.query.id) {
    return res.status(401).json({ message: "Invalid token" });
  }

  const page = await StrapiAPI.getPreviewProductPage(req.query.id);

  if (!page) {
    return res.status(401).json({ message: "Invalid slug" });
  }

  res.setPreviewData({ id: page.id });

  res.writeHead(307, { Location: `/${page.slug}` });
  res.end();
}
```

but when I use the live published mode, I am not able to do this.

What do yout think about it? Thanks
