### PR TITLE
Fix wording on label.published for FR translation

### DIFF
--- a/admin/src/translations/fr.json
+++ b/admin/src/translations/fr.json
@@ -1,4 +1,4 @@
 {
   "label.draft": "Ouvrir l'aperçu du brouillon",
-  "label.published": "Ouvrir la vue en direct"
+  "label.published": "Ouvrir la version publiée"
 }


### PR DESCRIPTION
Fix a small invalid wording for the `label.published` in the french translation.

The sentence "Ouvrir la vue en direct" doesn't really make sense in french.