### PR TITLE
Add params to find methods to find either draft or publish state

### DIFF
--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { get } = require( 'lodash' );
+
 const { getService, pluginId } = require( '../utils' );
 
 module.exports = {
@@ -25,10 +27,14 @@ module.exports = {
     const { contentTypes } = await getService( 'plugin' ).getConfig();
     const supportedType = contentTypes.find( type => type.uid === uid );
 
-    // Collection types will find by the ID and single types do not.
+    // Not sure if this is expected behavior, but using `find()` with single types
+    // seem to always return null when they are either in draft state or if they
+    // have `draftAndPublish` disabled entirely. To work around that, we use
+    // specific params here to find the single entity in either state.
+    const params = { publicationState: 'preview' };
     const entity = id
-      ? await strapi.service( uid ).findOne( id )
-      : await strapi.service( uid ).find();
+      ? await strapi.service( uid ).findOne( id, params )
+      : await strapi.service( uid ).find( params );
 
     // Raise warning if plugin is active but not properly configured with required env vars.
     if ( ! hasEnvVars ) {


### PR DESCRIPTION
Not sure if this is expected behavior, but using `strapi.service( uid ).find()` with single types seems to always return null when they are either in draft state or if they have `draftAndPublish` disabled. To work around that, we use `publicationState: preview` in the find params to get either type of entity in either state.

Related Issue https://github.com/mattmilburn/strapi-plugin-preview-button/issues/40