### PR TITLE
Release v0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-preview-button",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A plugin for Strapi CMS that adds a preview button and live view button to the content manager edit view.",
   "license": "MIT",
   "strapi": {

--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { get } = require( 'lodash' );
+
 const { getService, pluginId } = require( '../utils' );
 
 module.exports = {
@@ -25,10 +27,14 @@ module.exports = {
     const { contentTypes } = await getService( 'plugin' ).getConfig();
     const supportedType = contentTypes.find( type => type.uid === uid );
 
-    // Collection types will find by the ID and single types do not.
+    // Not sure if this is expected behavior, but using `find()` with single types
+    // seem to always return null when they are either in draft state or if they
+    // have `draftAndPublish` disabled entirely. To work around that, we use
+    // specific params here to find the single entity in either state.
+    const params = { publicationState: 'preview' };
     const entity = id
-      ? await strapi.service( uid ).findOne( id )
-      : await strapi.service( uid ).find();
+      ? await strapi.service( uid ).findOne( id, params )
+      : await strapi.service( uid ).find( params );
 
     // Raise warning if plugin is active but not properly configured with required env vars.
     if ( ! hasEnvVars ) {


### PR DESCRIPTION
# Included in this release

### 🐛 Bug fixes
* Fix bug where single types would return null if they were in draft state or have `draftAndPublish` disabled -  https://github.com/mattmilburn/strapi-plugin-preview-button/issues/40