### PR TITLE
Optional secret param for draft previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ STRAPI_PREVIEW_PUBLISHED_URL=https://example.com
 
 You must generate your own secret key to use for `STRAPI_PREVIEW_SECRET` which will also be given to the frontend app later.
 
+#### Optional Secret
+The `STRAPI_PREVIEW_SECRET` is optional and can be disabled in the plugin configuration.
+
 #### Draft and publish mode
 With `draftAndPublish` mode enabled for a content type, a preview button will render when the entry is in a draft state while a live view button will render when it is in a published state.
 
@@ -44,6 +47,7 @@ It is **not** required to enable `draftAndPublish` for content types using this 
 | property | type (default) | description |
 | - | - | - |
 | contentTypes | array (`[]`) | An array of objects describing which content types should use the preview button. |
+| requireDraftSecret | boolean (`true`) | A flag to optionally require a secret be configured for draft entries. |
 
 ### `contentTypes`
 An array of objects describing which content types should use the preview button.
@@ -192,6 +196,9 @@ https://example.com/api/preview?slug=aboute&secret=YOURSECRET
 // Published URL
 https://example.com/about
 ```
+
+### `requireDraftSecret`
+A flag to optionally require a secret be configured for draft entries. This is `true` by default.
 
 ## <a id="user-guide"></a>📘 User Guide
 

--- a/server/config.js
+++ b/server/config.js
@@ -2,13 +2,27 @@
 
 const { ValidationError } = require('@strapi/utils').errors;
 
+const { pluginId } = require( './utils' );
+
 module.exports = {
   default: {
     contentTypes: [],
+    requireSecret: true,
   },
   validator: config => {
     if ( ! config.contentTypes ) {
       return;
+    }
+
+    const requiredEnvVars = [
+      process.env.STRAPI_PREVIEW_SECRET,
+      process.env.STRAPI_PREVIEW_DRAFT_URL,
+      process.env.STRAPI_PREVIEW_PUBLISHED_URL,
+    ];
+
+    // Ensure env vars are set.
+    if ( ! requiredEnvVars.every( val => val ) ) {
+      throw new ValidationError( `Must define required environment variables for the ${pluginId} plugin.` );
     }
 
     // Ensure `contentTypes` is an array.

--- a/server/config.js
+++ b/server/config.js
@@ -7,7 +7,7 @@ const { pluginId } = require( './utils' );
 module.exports = {
   default: {
     contentTypes: [],
-    requireSecret: true,
+    requireDraftSecret: true,
   },
   validator: config => {
     if ( ! config.contentTypes ) {
@@ -20,7 +20,7 @@ module.exports = {
     ];
 
     // Maybe require the env SECRET.
-    if ( config.requireSecret ) {
+    if ( config.requireDraftSecret ) {
       requiredEnvVars.push( process.env.STRAPI_PREVIEW_SECRET );
     }
 

--- a/server/config.js
+++ b/server/config.js
@@ -14,11 +14,15 @@ module.exports = {
       return;
     }
 
-    const requiredEnvVars = [
-      process.env.STRAPI_PREVIEW_SECRET,
+    let requiredEnvVars = [
       process.env.STRAPI_PREVIEW_DRAFT_URL,
       process.env.STRAPI_PREVIEW_PUBLISHED_URL,
     ];
+
+    // Maybe require the env SECRET.
+    if ( config.requireSecret ) {
+      requiredEnvVars.push( process.env.STRAPI_PREVIEW_SECRET );
+    }
 
     // Ensure env vars are set.
     if ( ! requiredEnvVars.every( val => val ) ) {

--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { get } = require( 'lodash' );
-
 const { getService, pluginId } = require( '../utils' );
 
 module.exports = {
@@ -18,12 +16,6 @@ module.exports = {
   async findOne( ctx ) {
     const { uid, id } = ctx.request.params;
 
-    const hasEnvVars = [
-      process.env.STRAPI_PREVIEW_SECRET,
-      process.env.STRAPI_PREVIEW_DRAFT_URL,
-      process.env.STRAPI_PREVIEW_PUBLISHED_URL,
-    ].every( val => val );
-
     const { contentTypes } = await getService( 'plugin' ).getConfig();
     const supportedType = contentTypes.find( type => type.uid === uid );
 
@@ -36,13 +28,8 @@ module.exports = {
       ? await strapi.service( uid ).findOne( id, params )
       : await strapi.service( uid ).find( params );
 
-    // Raise warning if plugin is active but not properly configured with required env vars.
-    if ( ! hasEnvVars ) {
-      console.warn( `Environment variables required for ${pluginId} plugin must be defined before it can be used.` );
-    }
-
     // Return empty object if requirements are not met.
-    if ( ! hasEnvVars || ! supportedType || ! entity ) {
+    if ( ! supportedType || ! entity ) {
       return ctx.send( {} );
     }
 

--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -16,7 +16,7 @@ module.exports = {
   async findOne( ctx ) {
     const { uid, id } = ctx.request.params;
 
-    const { contentTypes, requireSecret } = await getService( 'plugin' ).getConfig();
+    const { contentTypes, requireDraftSecret } = await getService( 'plugin' ).getConfig();
     const supportedType = contentTypes.find( type => type.uid === uid );
 
     // Not sure if this is expected behavior, but using `find()` with single types
@@ -36,7 +36,7 @@ module.exports = {
     const urls = getService( 'preview-button' ).getPreviewUrls(
       entity,
       supportedType,
-      requireSecret
+      requireDraftSecret
     );
 
     // Return preview URLs.

--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -16,7 +16,7 @@ module.exports = {
   async findOne( ctx ) {
     const { uid, id } = ctx.request.params;
 
-    const { contentTypes } = await getService( 'plugin' ).getConfig();
+    const { contentTypes, requireSecret } = await getService( 'plugin' ).getConfig();
     const supportedType = contentTypes.find( type => type.uid === uid );
 
     // Not sure if this is expected behavior, but using `find()` with single types
@@ -33,7 +33,11 @@ module.exports = {
       return ctx.send( {} );
     }
 
-    const urls = getService( 'preview-button' ).getPreviewUrls( entity, supportedType );
+    const urls = getService( 'preview-button' ).getPreviewUrls(
+      entity,
+      supportedType,
+      requireSecret
+    );
 
     // Return preview URLs.
     ctx.send( { urls } );

--- a/server/services/preview-button.js
+++ b/server/services/preview-button.js
@@ -6,7 +6,7 @@ const qs = require( 'qs' );
 const { buildUrl } = require( '../utils' );
 
 module.exports = ( { strapi } ) => ( {
-  getPreviewUrls( entity, contentTypeConfig, requireSecret ) {
+  getPreviewUrls( entity, contentTypeConfig, requireDraftSecret ) {
     const { uid, targetField, draft, published } = contentTypeConfig;
 
     // If `targetField` is defined in either `draft` or `publish`, prioritize those
@@ -23,7 +23,7 @@ module.exports = ( { strapi } ) => ( {
     let draftQuery = get( draft, 'query', {} );
 
     // Maybe include the `secret` into the draft query params.
-    if ( requireSecret ) {
+    if ( requireDraftSecret ) {
       draftQuery.secret = process.env.STRAPI_PREVIEW_SECRET;
     }
 

--- a/server/services/preview-button.js
+++ b/server/services/preview-button.js
@@ -3,11 +3,10 @@
 const { get } = require( 'lodash' );
 const qs = require( 'qs' );
 
-const config = require( '../config' );
 const { buildUrl } = require( '../utils' );
 
 module.exports = ( { strapi } ) => ( {
-  getPreviewUrls( entity, contentTypeConfig ) {
+  getPreviewUrls( entity, contentTypeConfig, requireSecret ) {
     const { uid, targetField, draft, published } = contentTypeConfig;
 
     // If `targetField` is defined in either `draft` or `publish`, prioritize those
@@ -23,8 +22,10 @@ module.exports = ( { strapi } ) => ( {
     const draftBasePath = get( draft, 'basePath', null );
     let draftQuery = get( draft, 'query', {} );
 
-    // Include the required `secret` into the draft query params.
-    draftQuery.secret = process.env.STRAPI_PREVIEW_SECRET;
+    // Maybe include the `secret` into the draft query params.
+    if ( requireSecret ) {
+      draftQuery.secret = process.env.STRAPI_PREVIEW_SECRET;
+    }
 
     // Optionally include the `targetField` value in the draft query params.
     // Only collection types truly require the `targetField`, while single types


### PR DESCRIPTION
Add a `requireDraftSecret` configuration option to allow disabling the required secret.