### PR TITLE
Inject column into list view

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 * Customize which content types should use the preview button.
 * Customize endpoints for draft and published URLs.
 * Map custom values from an entry's data into preview URLs.
+* Include icons for preview and copy link functions in list view.
 * Supports collection and single types.
 
 ## <a id="installation"></a>💎 Installation
@@ -32,6 +33,7 @@ yarn add strapi-plugin-preview-button@latest
 | contentTypes[].uid | string | The `uid` value of either a single or collection type. |
 | contentTypes[].draft | object (`{}`) | A configuration object to enable a draft preview button. |
 | contentTypes[].published | object (`{}`) | A configuration object to enable a live view button. |
+  | injectListViewColumn | boolean (`true`) | Set to `false` to disable the preview and copy link buttons from displaying in list view. |
 
 ### `contentTypes`
 An array of objects describing which content types should use the preview button.
@@ -139,7 +141,7 @@ module.exports = ( { env } ) => {
 };
 ```
 
-#### Use a `STRAPI_PREVIEW_SECRET` key with preview URLs
+#### Use a secret key with preview URLs
 You can optionally use a secret key with your preview URLs by taking advantage of environment vars and the `query` prop. See example below.
 
 ```js
@@ -199,6 +201,22 @@ module.exports = {
             copy: false,
           },
         },
+        // etc.
+      ],
+    },
+  },
+};
+```
+
+### `injectListViewColumn`
+Set to `false` to disable the preview and copy link buttons from displaying in list view. This applies to all configured content types.
+
+```js
+module.exports = {
+  'preview-button': {
+    config: {
+      injectListViewColumn: false,
+      contentTypes: [
         // etc.
       ],
     },

--- a/admin/src/components/CopyLinkButton/index.js
+++ b/admin/src/components/CopyLinkButton/index.js
@@ -5,6 +5,7 @@ import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { Button } from '@strapi/design-system';
 import { useNotification } from '@strapi/helper-plugin';
 import { Link } from '@strapi/icons';
+
 import { getTrad } from '../../utils';
 
 const CopyLinkButton = ( { isDraft, url } ) => {

--- a/admin/src/components/ListViewTableCell/index.js
+++ b/admin/src/components/ListViewTableCell/index.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useIntl } from 'react-intl';
+import { Button } from '@strapi/design-system';
+import { ExternalLink } from '@strapi/icons';
+
+import { PREVIEW_WINDOW_NAME } from '../../constants';
+import { getTrad } from '../../utils';
+
+const ListViewTableCell = ( { isDraft, url } ) => {
+  const { formatMessage } = useIntl();
+
+  const handleClick = event => {
+    if ( ! url ) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    window.open( url, PREVIEW_WINDOW_NAME );
+  };
+
+  return (
+    <Button
+      size="S"
+      startIcon={ <ExternalLink /> }
+      variant="secondary"
+      onClick={ handleClick }
+    >
+      { formatMessage( isDraft ? {
+        id: getTrad( 'label.open-preview-link' ),
+        defaultMessage: 'Open preview',
+      } : {
+        id: getTrad( 'label.open-link' ),
+        defaultMessage: 'Open link',
+      } ) }
+    </Button>
+  );
+};
+
+ListViewTableCell.propTypes = {
+  isDraft: PropTypes.bool,
+  url: PropTypes.string,
+};
+
+export default ListViewTableCell;

--- a/admin/src/components/ListViewTableCell/index.js
+++ b/admin/src/components/ListViewTableCell/index.js
@@ -1,45 +1,72 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Button } from '@strapi/design-system';
-import { ExternalLink } from '@strapi/icons';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { Flex, IconButton } from '@strapi/design-system';
+import { stopPropagation, useNotification } from '@strapi/helper-plugin';
+import { ExternalLink, Link } from '@strapi/icons';
 
 import { PREVIEW_WINDOW_NAME } from '../../constants';
 import { getTrad } from '../../utils';
 
-const ListViewTableCell = ( { isDraft, url } ) => {
+const ListViewTableCell = ( { canCopy, isDraft, url } ) => {
   const { formatMessage } = useIntl();
+  const toggleNotification = useNotification();
 
   const handleClick = event => {
     if ( ! url ) {
       return;
     }
 
-    event.preventDefault();
-    event.stopPropagation();
-
     window.open( url, PREVIEW_WINDOW_NAME );
   };
 
   return (
-    <Button
-      size="S"
-      startIcon={ <ExternalLink /> }
-      variant="secondary"
-      onClick={ handleClick }
-    >
-      { formatMessage( isDraft ? {
-        id: getTrad( 'label.open-preview-link' ),
-        defaultMessage: 'Open preview',
-      } : {
-        id: getTrad( 'label.open-link' ),
-        defaultMessage: 'Open link',
-      } ) }
-    </Button>
+    <Flex { ...stopPropagation }>
+      <IconButton
+        onClick={ handleClick }
+        label={ formatMessage( isDraft ? {
+          id: getTrad( 'label.draft' ),
+          defaultMessage: 'Open draft preview',
+        } : {
+          id: getTrad( 'label.published' ),
+          defaultMessage: 'Open live view',
+        } ) }
+        icon={ <ExternalLink /> }
+        noBorder
+      />
+      { canCopy && (
+        <CopyToClipboard
+          text={ url }
+          onCopy={ () => {
+            toggleNotification( {
+              type: 'success',
+              message: {
+                id: 'notification.link-copied',
+                defaultMessage: 'Link copied to the clipboard',
+              },
+            } );
+          } }
+        >
+          <IconButton
+            icon={ <Link /> }
+            label={ formatMessage( isDraft ? {
+              id: getTrad( 'label.copy-preview-link' ),
+              defaultMessage: 'Copy preview link',
+            } : {
+              id: getTrad( 'label.copy-link' ),
+              defaultMessage: 'Copy link',
+            } ) }
+            noBorder
+          />
+        </CopyToClipboard>
+      ) }
+    </Flex>
   );
 };
 
 ListViewTableCell.propTypes = {
+  canCopy: PropTypes.bool,
   isDraft: PropTypes.bool,
   url: PropTypes.string,
 };

--- a/admin/src/components/index.js
+++ b/admin/src/components/index.js
@@ -1,4 +1,5 @@
 export { default as CopyLinkButton } from './CopyLinkButton';
 export { default as Initializer } from './Initializer';
 export { default as Injector } from './Injector';
+export { default as ListViewTableCell } from './ListViewTableCell';
 export { default as PreviewButton } from './PreviewButton';

--- a/admin/src/contentManagerHooks/add-preview-column.js
+++ b/admin/src/contentManagerHooks/add-preview-column.js
@@ -42,7 +42,11 @@ const addPreviewColumn = ( { displayedHeaders, layout }, pluginConfig ) => {
           }
 
           return (
-            <ListViewTableCell isDraft={ isDraft } url={ url } />
+            <ListViewTableCell
+              canCopy={ stateConfig?.copy === false ? false : true }
+              isDraft={ isDraft }
+              url={ url }
+            />
           );
         },
       },

--- a/admin/src/contentManagerHooks/add-preview-column.js
+++ b/admin/src/contentManagerHooks/add-preview-column.js
@@ -5,12 +5,12 @@ import { ListViewTableCell } from '../components';
 import { parseUrl, pluginId } from '../utils';
 
 const addPreviewColumn = ( { displayedHeaders, layout }, pluginConfig ) => {
-  const { contentTypes } = pluginConfig;
+  const { contentTypes, disableListViewButton } = pluginConfig;
   const match = contentTypes?.find( type => type.uid === layout.contentType.uid );
   const isSupportedType = !! match;
 
   // Do nothing if this feature is not a supported type for the preview button.
-  if ( ! isSupportedType ) {
+  if ( ! isSupportedType || disableListViewButton ) {
     return {
       displayedHeaders,
       layout,

--- a/admin/src/contentManagerHooks/add-preview-column.js
+++ b/admin/src/contentManagerHooks/add-preview-column.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Typography } from '@strapi/design-system';
+
+import { ListViewTableCell } from '../components';
+import { parseUrl, pluginId } from '../utils';
+
+const addPreviewColumn = ( { displayedHeaders, layout }, pluginConfig ) => {
+  const { contentTypes } = pluginConfig;
+  const match = contentTypes?.find( type => type.uid === layout.contentType.uid );
+  const isSupportedType = !! match;
+
+  // Do nothing if this feature is not a supported type for the preview button.
+  if ( ! isSupportedType ) {
+    return {
+      displayedHeaders,
+      layout,
+    };
+  }
+
+  return {
+    displayedHeaders: [
+      ...displayedHeaders,
+      {
+        key: '__preview_key__',
+        fieldSchema: {
+          type: 'string',
+        },
+        metadatas: {
+          label: 'Preview Link',
+          searchable: false,
+          sortable: false,
+        },
+        name: 'preview',
+        cellFormatter: data => {
+          const hasDraftAndPublish = layout.contentType.options.draftAndPublish === true;
+          const isDraft = hasDraftAndPublish && ! data.publishedAt;
+          const stateConfig = isSupportedType && match[ isDraft ? 'draft' : 'published' ];
+          const url = parseUrl( stateConfig, data );
+
+          if ( ! url ) {
+            return null;
+          }
+
+          return (
+            <ListViewTableCell isDraft={ isDraft } url={ url } />
+          );
+        },
+      },
+    ],
+    layout,
+  };
+}
+
+export default addPreviewColumn;

--- a/admin/src/contentManagerHooks/add-preview-column.js
+++ b/admin/src/contentManagerHooks/add-preview-column.js
@@ -5,12 +5,12 @@ import { ListViewTableCell } from '../components';
 import { parseUrl, pluginId } from '../utils';
 
 const addPreviewColumn = ( { displayedHeaders, layout }, pluginConfig ) => {
-  const { contentTypes, disableListViewButton } = pluginConfig;
+  const { contentTypes, injectListViewColumn } = pluginConfig;
   const match = contentTypes?.find( type => type.uid === layout.contentType.uid );
   const isSupportedType = !! match;
 
   // Do nothing if this feature is not a supported type for the preview button.
-  if ( ! isSupportedType || disableListViewButton ) {
+  if ( ! isSupportedType || ! injectListViewColumn ) {
     return {
       displayedHeaders,
       layout,

--- a/admin/src/contentManagerHooks/index.js
+++ b/admin/src/contentManagerHooks/index.js
@@ -1,0 +1,1 @@
+export { default as addPreviewColumn } from './add-preview-column';

--- a/server/config.js
+++ b/server/config.js
@@ -5,6 +5,7 @@ const { get, has } = require( 'lodash' );
 
 module.exports = {
   default: {
+    injectListViewColumn: true,
     contentTypes: [],
   },
   validator: config => {


### PR DESCRIPTION
This adds the preview and copy link buttons into the content manager list view.

It can be disabled with the `injectListViewColumn: false` config option.