### PR TITLE
Replace initial data passed to usePreviewUrl by modifiedData

### DIFF
--- a/admin/src/components/Injector/index.js
+++ b/admin/src/components/Injector/index.js
@@ -19,7 +19,7 @@ const Injector = () => {
     isLoading,
     isSupportedType,
     url,
-  } = usePreviewUrl( uid, initialData, isDraft, isCreatingEntry );
+  } = usePreviewUrl( uid, modifiedData, isDraft, isCreatingEntry );
 
   if ( ! url || ! isSupportedType || isCreatingEntry || isLoading ) {
     return null;

--- a/admin/src/components/Injector/index.js
+++ b/admin/src/components/Injector/index.js
@@ -8,7 +8,6 @@ const Injector = () => {
   const {
     allLayoutData,
     hasDraftAndPublish,
-    initialData,
     isCreatingEntry,
     modifiedData,
   } = useCMEditViewDataManager();

--- a/admin/src/hooks/use-preview-url.js
+++ b/admin/src/hooks/use-preview-url.js
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react';
-import qs from 'qs';
 
 import { usePluginConfig} from '../hooks';
-import { parseUrl, pluginId } from '../utils';
+import { parseUrl } from '../utils';
 
 const usePreviewUrl = ( uid, data, isDraft, isCreating ) => {
   const [ url, setUrl ] = useState( null );
   const [ canCopy, setCopy ] = useState( true );
   const { config, isLoading } = usePluginConfig();
   const { contentTypes } = config;
+
+  const { updatedAt } = data;
 
   const match = contentTypes?.find( type => type.uid === uid );
   const isSupportedType = !! match;
@@ -27,7 +28,7 @@ const usePreviewUrl = ( uid, data, isDraft, isCreating ) => {
 
     setUrl( url );
     setCopy( stateConfig?.copy === false ? false : true );
-  }, [ isDraft, isCreating, isLoading ] );
+  }, [ isDraft, isCreating, isLoading, updatedAt ] );
 
   return {
     canCopy,

--- a/admin/src/hooks/use-preview-url.js
+++ b/admin/src/hooks/use-preview-url.js
@@ -8,7 +8,6 @@ const usePreviewUrl = ( uid, data, isDraft, isCreating ) => {
   const [ canCopy, setCopy ] = useState( true );
   const { config, isLoading } = usePluginConfig();
   const { contentTypes } = config;
-
   const { updatedAt } = data;
 
   const match = contentTypes?.find( type => type.uid === uid );


### PR DESCRIPTION
**Description**
According to the [issue 59](https://github.com/mattmilburn/strapi-plugin-preview-button/issues/59). I think the issue is due to the fact that the user @AndreasFaust that report the issue (and myself included) are using Strapi lifefycles to update the slug. Then when we changed our slug, the preview url of the Preview Button is not updated because it still use the initialData. We have to remove the Edit Page to apply our changes 

**Related Issue**
https://github.com/mattmilburn/strapi-plugin-preview-button/issues/59

**Types of changes**
- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change

**What changed ?**
I propose to replace the initialData from useCMEditViewDataManager() passed to usePreviewUrl() utility by modifiedData. Then we are able to get the updatedAt attribute change on save to fire another event to the usePreviewUrl() useEffect hook, and then dynamically change de preview url after the lifecycles are executed.  