### PR TITLE
Replace unmatched with empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn add strapi-plugin-preview-button@latest
 | contentTypes[].uid | string | The `uid` value of either a single or collection type. |
 | contentTypes[].draft | object (`{}`) | A configuration object to enable a draft preview button. |
 | contentTypes[].published | object (`{}`) | A configuration object to enable a live view button. |
-  | injectListViewColumn | boolean (`true`) | Set to `false` to disable the preview and copy link buttons from displaying in list view. |
+| injectListViewColumn | boolean (`true`) | Set to `false` to disable the preview and copy link buttons from displaying in list view. |
 
 ### `contentTypes`
 An array of objects describing which content types should use the preview button.

--- a/admin/src/utils/interpolate.js
+++ b/admin/src/utils/interpolate.js
@@ -3,6 +3,9 @@ const interpolate = ( str, data = {} ) => {
     str = str.replace( new RegExp( `{${key}}`, 'g' ), value );
   } );
 
+  // Replace any remaining values with an empty string.
+  str = str.replace( new RegExp( `{(.*)}`, 'g' ), '' );
+
   return str;
 };
 


### PR DESCRIPTION
Instead of leaving unmatched params in the URL template, replace them with an empty string.