### PR TITLE
Release v1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn add strapi-plugin-preview-button@latest
 | contentTypes[].uid | string | The `uid` value of either a single or collection type. |
 | contentTypes[].draft | object (`{}`) | A configuration object to enable a draft preview button. |
 | contentTypes[].published | object (`{}`) | A configuration object to enable a live view button. |
-  | injectListViewColumn | boolean (`true`) | Set to `false` to disable the preview and copy link buttons from displaying in list view. |
+| injectListViewColumn | boolean (`true`) | Set to `false` to disable the preview and copy link buttons from displaying in list view. |
 
 ### `contentTypes`
 An array of objects describing which content types should use the preview button.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ yarn add strapi-plugin-preview-button@latest
 | contentTypes[].draft | object (`{}`) | A configuration object to enable a draft preview button. |
 | contentTypes[].published | object (`{}`) | A configuration object to enable a live view button. |
 | injectListViewColumn | boolean (`true`) | Set to `false` to disable the preview and copy link buttons from displaying in list view. |
+| openTarget | string | Set to `_blank` to always open preview page in a new tab or window. Otherwise the preview will re-use the same preview tab or window. |
 
 ### `contentTypes`
 An array of objects describing which content types should use the preview button.
@@ -117,6 +118,8 @@ http://localhost:3000/blog/my-post
 By using `{curly_braces}`, you can map values from the entry data into your preview URLs to customize the URL however you like.
 
 For example, depending on how you are choosing to handle your preview method, you could pass an `id` value to your **draft preview** but pass a `slug` value to your **live view**.
+
+> **Unmatched values** will be replaced with an empty string.
 
 ```js
 {
@@ -228,6 +231,24 @@ module.exports = {
 Ideally, the preview and copy link buttons in list view should appear alongside the other action icons for each row in the table. However, Strapi does not currently provide a hook to append new icons to that column. For now, this plugin will add its own "Preview" column with the extra icon actions.
 
 <img style="width: 960px; height: auto;" src="public/list-view.png" alt="Screenshot for list view in Strapi preview button plugin" />
+
+### `openTarget`
+By default this value is set to `StrapiPreview`. It is used in the `window.open` function for the preview button to always open in the same tab.
+
+If you would rather disable this and, for example, have the preview button always open in a new tab, you could use `_blank` as the value. Any special target keywords such as `_blank`, `_top`, `_self`, or `_parent` are acceptable values.
+
+```js
+module.exports = {
+  'preview-button': {
+    config: {
+      openTarget: '_blank',
+      contentTypes: [
+        // etc.
+      ],
+    },
+  },
+};
+```
 
 ## <a id="user-guide"></a>📘 User Guide
 

--- a/admin/src/components/Injector/index.js
+++ b/admin/src/components/Injector/index.js
@@ -1,7 +1,9 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 
 import { usePreviewUrl } from '../../hooks';
+import { pluginId } from '../../utils';
 import { CopyLinkButton, PreviewButton } from '../';
 
 const Injector = () => {
@@ -11,6 +13,7 @@ const Injector = () => {
     isCreatingEntry,
     modifiedData,
   } = useCMEditViewDataManager();
+  const { openTarget } = useSelector( state => state[ `${pluginId}_config` ].config );
   const isDraft = hasDraftAndPublish && ! modifiedData.publishedAt;
   const { uid } = allLayoutData.contentType;
   const {
@@ -26,7 +29,7 @@ const Injector = () => {
 
   return (
     <>
-      <PreviewButton isDraft={ isDraft } url={ url } />
+      <PreviewButton isDraft={ isDraft } url={ url } target={ openTarget } />
       { canCopy && <CopyLinkButton isDraft={ isDraft } url={ url } /> }
     </>
   );

--- a/admin/src/components/Injector/index.js
+++ b/admin/src/components/Injector/index.js
@@ -19,7 +19,7 @@ const Injector = () => {
     isLoading,
     isSupportedType,
     url,
-  } = usePreviewUrl( uid, initialData, isDraft, isCreatingEntry );
+  } = usePreviewUrl( uid, modifiedData, isDraft, isCreatingEntry );
 
   if ( ! url || ! isSupportedType || isCreatingEntry || isLoading ) {
     return null;

--- a/admin/src/components/Injector/index.js
+++ b/admin/src/components/Injector/index.js
@@ -8,7 +8,6 @@ const Injector = () => {
   const {
     allLayoutData,
     hasDraftAndPublish,
-    initialData,
     isCreatingEntry,
     modifiedData,
   } = useCMEditViewDataManager();

--- a/admin/src/components/ListViewTableCell/index.js
+++ b/admin/src/components/ListViewTableCell/index.js
@@ -6,10 +6,9 @@ import { Flex, IconButton } from '@strapi/design-system';
 import { stopPropagation, useNotification } from '@strapi/helper-plugin';
 import { ExternalLink, Link } from '@strapi/icons';
 
-import { PREVIEW_WINDOW_NAME } from '../../constants';
 import { getTrad } from '../../utils';
 
-const ListViewTableCell = ( { canCopy, isDraft, url } ) => {
+const ListViewTableCell = ( { canCopy, isDraft, target, url } ) => {
   const { formatMessage } = useIntl();
   const toggleNotification = useNotification();
 
@@ -18,7 +17,7 @@ const ListViewTableCell = ( { canCopy, isDraft, url } ) => {
       return;
     }
 
-    window.open( url, PREVIEW_WINDOW_NAME );
+    window.open( url, target );
   };
 
   return (
@@ -68,6 +67,7 @@ const ListViewTableCell = ( { canCopy, isDraft, url } ) => {
 ListViewTableCell.propTypes = {
   canCopy: PropTypes.bool,
   isDraft: PropTypes.bool,
+  target: PropTypes.string,
   url: PropTypes.string,
 };
 

--- a/admin/src/components/PreviewButton/index.js
+++ b/admin/src/components/PreviewButton/index.js
@@ -4,10 +4,9 @@ import { useIntl } from 'react-intl';
 import { Button } from '@strapi/design-system';
 import { ExternalLink } from '@strapi/icons';
 
-import { PREVIEW_WINDOW_NAME } from '../../constants';
 import { getTrad } from '../../utils';
 
-const PreviewButton = ( { isDraft, url } ) => {
+const PreviewButton = ( { isDraft, target, url } ) => {
   const { formatMessage } = useIntl();
 
   const handleClick = event => {
@@ -16,7 +15,7 @@ const PreviewButton = ( { isDraft, url } ) => {
       return;
     }
 
-    window.open( url, PREVIEW_WINDOW_NAME );
+    window.open( url, target );
   };
 
   return (
@@ -40,6 +39,7 @@ const PreviewButton = ( { isDraft, url } ) => {
 
 PreviewButton.propTypes = {
   isDraft: PropTypes.bool,
+  target: PropTypes.string,
   url: PropTypes.string,
 };
 

--- a/admin/src/constants.js
+++ b/admin/src/constants.js
@@ -1,6 +1,4 @@
 import pluginId from './utils/plugin-id';
 
-export const PREVIEW_WINDOW_NAME = 'StrapiPreview';
-
 export const RESOLVE_PREVIEW = `${pluginId}/resolve-data`;
 export const RESOLVE_CONFIG = `${pluginId}/resolve-config`;

--- a/admin/src/contentManagerHooks/add-preview-column.js
+++ b/admin/src/contentManagerHooks/add-preview-column.js
@@ -5,7 +5,7 @@ import { ListViewTableCell } from '../components';
 import { parseUrl, pluginId } from '../utils';
 
 const addPreviewColumn = ( { displayedHeaders, layout }, pluginConfig ) => {
-  const { contentTypes, injectListViewColumn } = pluginConfig;
+  const { contentTypes, injectListViewColumn, openTarget } = pluginConfig;
   const match = contentTypes?.find( type => type.uid === layout.contentType.uid );
   const isSupportedType = !! match;
 
@@ -45,6 +45,7 @@ const addPreviewColumn = ( { displayedHeaders, layout }, pluginConfig ) => {
             <ListViewTableCell
               canCopy={ stateConfig?.copy === false ? false : true }
               isDraft={ isDraft }
+              target={ openTarget }
               url={ url }
             />
           );

--- a/admin/src/hooks/use-preview-url.js
+++ b/admin/src/hooks/use-preview-url.js
@@ -1,14 +1,15 @@
 import { useEffect, useState } from 'react';
-import qs from 'qs';
 
 import { usePluginConfig} from '../hooks';
-import { parseUrl, pluginId } from '../utils';
+import { parseUrl } from '../utils';
 
 const usePreviewUrl = ( uid, data, isDraft, isCreating ) => {
   const [ url, setUrl ] = useState( null );
   const [ canCopy, setCopy ] = useState( true );
   const { config, isLoading } = usePluginConfig();
   const { contentTypes } = config;
+
+  const { updatedAt } = data;
 
   const match = contentTypes?.find( type => type.uid === uid );
   const isSupportedType = !! match;
@@ -27,7 +28,7 @@ const usePreviewUrl = ( uid, data, isDraft, isCreating ) => {
 
     setUrl( url );
     setCopy( stateConfig?.copy === false ? false : true );
-  }, [ isDraft, isCreating, isLoading ] );
+  }, [ isDraft, isCreating, isLoading, updatedAt ] );
 
   return {
     canCopy,

--- a/admin/src/hooks/use-preview-url.js
+++ b/admin/src/hooks/use-preview-url.js
@@ -8,7 +8,6 @@ const usePreviewUrl = ( uid, data, isDraft, isCreating ) => {
   const [ canCopy, setCopy ] = useState( true );
   const { config, isLoading } = usePluginConfig();
   const { contentTypes } = config;
-
   const { updatedAt } = data;
 
   const match = contentTypes?.find( type => type.uid === uid );

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -34,6 +34,10 @@ export default {
       // Register hooks.
       app.registerHook( 'Admin/CM/pages/ListView/inject-column-in-table', listViewColumnHook );
     } catch ( _err ) {
+      /**
+       * @TODO - Apparently this is causing issues when this fails for a logged-out user.
+       */
+
       // Probably just failed because user is not logged in, which is fine.
       return;
     }

--- a/admin/src/utils/interpolate.js
+++ b/admin/src/utils/interpolate.js
@@ -3,6 +3,9 @@ const interpolate = ( str, data = {} ) => {
     str = str.replace( new RegExp( `{${key}}`, 'g' ), value );
   } );
 
+  // Replace any remaining values with an empty string.
+  str = str.replace( new RegExp( `{(.*)}`, 'g' ), '' );
+
   return str;
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-preview-button",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A plugin for Strapi CMS that adds a preview button and live view button to the content manager edit view.",
   "license": "MIT",
   "strapi": {

--- a/server/config.js
+++ b/server/config.js
@@ -3,10 +3,13 @@
 const { ValidationError } = require('@strapi/utils').errors;
 const { get, has } = require( 'lodash' );
 
+const { PREVIEW_WINDOW_NAME } = require( './constants' );
+
 module.exports = {
   default: {
     injectListViewColumn: true,
     contentTypes: [],
+    openTarget: PREVIEW_WINDOW_NAME,
   },
   validator: config => {
     if ( ! config.contentTypes ) {

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  PREVIEW_WINDOW_NAME: 'StrapiPreview',
+};

--- a/server/controllers/preview-button.js
+++ b/server/controllers/preview-button.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { getService, pluginId } = require( '../utils' );
+const { getService } = require( '../utils' );
 
 module.exports = {
   async config( ctx ) {


### PR DESCRIPTION
# Included in this release

### 🐛 Bug fixes
* Fix issue where preview URL does not update after saving with new `slug` value.

### 💅🏻 Enhancements
* Add `openTarget` config option to allow opening multiple tabs instead of re-using the same tab.
* Replace unmatched vars in URL templates with empty string instead of ignoring them.

### ⚙️ Chore
* Add explanation of `openTarget` option to the README.