### PR TITLE
Add "before build url" hook

### DIFF
--- a/admin/src/constants.js
+++ b/admin/src/constants.js
@@ -1,4 +1,6 @@
 import pluginId from './utils/plugin-id';
 
+export const HOOK_BEFORE_BUILD_URL = 'plugin/preview-button/before-build-url';
+
 export const RESOLVE_PREVIEW = `${pluginId}/resolve-data`;
 export const RESOLVE_CONFIG = `${pluginId}/resolve-config`;

--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -2,12 +2,15 @@ import { prefixPluginTranslations, request } from '@strapi/helper-plugin';
 
 import { getTrad, pluginId, pluginName } from './utils';
 import { Initializer, Injector } from './components';
+import { HOOK_BEFORE_BUILD_URL } from './constants';
 import { addPreviewColumn } from './contentManagerHooks';
 import reducers from './reducers';
 
 export default {
   register( app ) {
     app.addReducers( reducers );
+
+    app.createHook( HOOK_BEFORE_BUILD_URL );
 
     app.registerPlugin( {
       id: pluginId,

--- a/server/config.js
+++ b/server/config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { ValidationError } = require('@strapi/utils').errors;
-const { get, has } = require( 'lodash' );
+const has = require( 'lodash/has' );
 
 const { PREVIEW_WINDOW_NAME } = require( './constants' );
 


### PR DESCRIPTION
This adds a `plugin/preview-button/before-build-url` hook to allow a plugin to filter the params that will be used to apply advanced logic to building the preview URL.