### PR TITLE
Refactor config and hooks

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,7 +12,7 @@
 ---
 
 ## Migrate from v1 to v2
-There is only one breaking change when migrating from version 1 to 2 of this plugin. The config options for `injectListViewColumn` and `openTarget` have now moved to the `pluginOptions` prop of model schemas.
+The breaking changes in this migration focus on improving plugin options and also a simple find and replace for a parameter name.
 
 #### `injectListViewColumn` and `openTarget`
 Previously, these config options were used alongside the rest of the config options in `./config/plugins.js` but they have moved to the `pluginOptions` prop of a model schema and will need to be applied to each schema individually.
@@ -56,7 +56,7 @@ module.exports = {
   },
   "pluginOptions": {
     "preview-button": {
-      "listViewColumn": false,
+      "listViewColumn": true,
       "openTarget": "StrapiPreview"
     }
   },
@@ -64,6 +64,55 @@ module.exports = {
     // etc.
   }
 }
+```
+
+### The parameters for the `before-build-url` custom hook have changed
+Previously, the parameters for the custom hook `before-build-url` included a `state` prop which should be returned by your custom hook. This prop name is changing from `state` to `options`.
+
+#### ❌ Not correct
+```js
+// ./admin/src/index.js
+export default {
+  bootstrap(app) {
+    app.registerHook('plugin/preview-button/before-build-url', ({ data, state }) => {
+      const query = state?.query ?? {};
+
+      // Return modified `state` object here.
+      return {
+        state: {
+          ...state,
+          query: {
+            ...query,
+            example: 'EXAMPLE',
+          },
+        },
+      };
+    });
+  },
+};
+```
+
+#### ✅ Correct
+```js
+// ./admin/src/index.js
+export default {
+  bootstrap(app) {
+    app.registerHook('plugin/preview-button/before-build-url', ({ data, options }) => {
+      const query = options?.query ?? {};
+
+      // Return modified `state` object here.
+      return {
+        options: {
+          ...options,
+          query: {
+            ...query,
+            example: 'EXAMPLE',
+          },
+        },
+      };
+    });
+  },
+};
 ```
 
 ---

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,8 +4,71 @@
   <p>Follow our migration guides to keep your preview button plugin up-to-date.</p>
 </div>
 
-## Migrate from v0.x to v1.0.0
+## Get Started
 
+* [Migrate from v1 to v2](#migrate-from-v1-to-v2)
+* [Migrate from v0 to v1](#migrate-from-v0-to-v1)
+
+---
+
+## Migrate from v1 to v2
+There is only one breaking change when migrating from version 1 to 2 of this plugin. The config options for `injectListViewColumn` and `openTarget` have now moved to the `pluginOptions` prop of model schemas.
+
+#### `injectListViewColumn` and `openTarget`
+Previously, these config options were used alongside the rest of the config options in `./config/plugins.js` but they have moved to the `pluginOptions` prop of a model schema and will need to be applied to each schema individually.
+
+In addition to the new location, the `injectListViewColumn` option is renamed to `listViewColumn` and it is set to `true` by default. You can disable the extra column by setting this value to `false` like in the code below.
+
+This change allows Strapi to inject a custom column into the content manager's list view without relying on fetching data, which solves issues that were related to this feature.
+
+#### ❌ Not correct
+```js
+// ./config/plugins.js
+'use strict';
+
+module.exports = {
+  'preview-button': {
+    config: {
+      injectListViewColumn: true,
+      openTarget: 'StrapiPreview',
+      contentTypes: [
+        // etc.
+      ],
+    },
+  },
+};
+```
+
+#### ✅ Correct
+```js
+// ./src/api/page/content-types/page/schema.js
+{
+  "kind": "collectionType",
+  "collectionName": "pages",
+  "info": {
+    "singularName": "page",
+    "pluralName": "pages",
+    "displayName": "Page",
+    "description": ""
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "preview-button": {
+      "listViewColumn": false,
+      "openTarget": "StrapiPreview"
+    }
+  },
+  "attributes": {
+    // etc.
+  }
+}
+```
+
+---
+
+## Migrate from v0 to v1
 The breaking changes in this migration are focused on configuration while simplifying code and requirements. As a result, much of the plugin configuration has changed.
 
 ### Environment vars are no longer required
@@ -20,6 +83,7 @@ STRAPI_PREVIEW_PUBLISHED_URL=https://example.com
 This is now optional and requires no extra handling from this plugin. To continue using these env vars, simply include them as you see below:
 
 ```js
+// ./config/plugins.js
 module.exports = ({ env }) => {
   'preview-button': {
     config: {
@@ -58,6 +122,7 @@ A "Copy Link" button has been added beneath the preview button in the content ma
 If you wish to disable this button for the draft or published state (or both) then you need to use `copy: false` for `draft` and `published` configurations as you see below:
 
 ```js
+// ./config/plugins.js
 {
   uid: 'api::page.page',
   draft: {
@@ -81,6 +146,7 @@ An icon button for the preview and copy buttons have been added to a new column 
 If you wish to disable this, set it to `false`. This applies to all configured content types.
 
 ```js
+// ./config/plugins.js
 module.exports = {
   'preview-button': {
     config: {

--- a/README.md
+++ b/README.md
@@ -315,7 +315,6 @@ The `package.json` is required for a Strapi plugin.
 
 ```js
 // ./package.json
-
 {
   "name": "example",
   "version": "0.1.0",
@@ -339,13 +338,12 @@ module.exports = require('./admin/src').default;
 
 In the main plugin file below, we register the plugin in the `register` method and we register the hook with the `bootstrap` method.
 
-The `state` argument is the original config object from `config/plugins.js`. So if you are editing a `Page` in draft mode, you will get the draft config for `Pages` from your plugin config passed into the callback.
+The `options` parameter is the original config object from `config/plugins.js`. So if you are editing a `Page` in draft mode, you will get the draft config for `Pages` from your plugin config passed into the callback and vice-versa with published mode.
 
-Here you can modify and return `state` while using `data` to make decisions.
+Here you will modify and return `options` while using `data` as a helper. In this example, we are just adding on a `foo=bar` query parameter to demonstrate how this hook can be utilized for more dynamic URLs.
 
 ```js
 // ./admin/src/index.js
-
 export default {
   register(app) {
     app.registerPlugin({
@@ -355,16 +353,16 @@ export default {
   },
 
   bootstrap(app) {
-    app.registerHook('plugin/preview-button/before-build-url', ({ state, data }) => {
-      const query = state?.query ?? {};
+    app.registerHook('plugin/preview-button/before-build-url', ({ data, options }) => {
+      const query = options?.query ?? {};
 
-      // Return modified `state` object here.
+      // Return modified `options` object here and use `data` however you like.
       return {
-        state: {
-          ...state,
+        options: {
+          ...options,
           query: {
             ...query,
-            example: 'EXAMPLE',
+            foo: 'bar',
           },
         },
       };

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 * [Features](#features)
 * [Installation](#installation)
 * [Configuration](#configuration)
+* [Plugin Options](#plugin-options)
 * [Extending](#extending)
 * [User Guide](#user-guide)
 * [Migration](#migration)
@@ -17,13 +18,13 @@
 
 ## <a id="features"></a>✨ Features
 * Adds a new button in content manager sidebar which links the user to a preview or live view of a frontend app view.
-* Include optional button to copy the preview link to your clipboard.
+* Optional preview button column in a collection's list view.
+* Optional button to copy the preview link to your clipboard.
 * Customize which content types should use the preview button.
 * Customize endpoints for draft and published URLs.
 * Map values from an entry's data into preview URLs.
 * Supports collection and single types.
-* Supports localization with the `i18n` Strapi plugin.
-* Optionally include preview and copy icons in list view.
+* Supports localization with the `@strapi/plugin-i18n` plugin.
 
 ## <a id="installation"></a>💎 Installation
 ```bash
@@ -37,8 +38,6 @@ yarn add strapi-plugin-preview-button@latest
 | contentTypes[].uid | string | The `uid` value of either a single or collection type. |
 | contentTypes[].draft | object (`{}`) | A configuration object to enable a draft preview button. |
 | contentTypes[].published | object (`{}`) | A configuration object to enable a live view button. |
-| injectListViewColumn | boolean (`true`) | Set to `false` to disable the preview and copy link buttons from displaying in list view. |
-| openTarget | string | Set to `_blank` to always open preview page in a new tab or window. Otherwise the preview will re-use the same preview tab or window. |
 
 ### `contentTypes`
 An array of objects describing which content types should use the preview button.
@@ -127,6 +126,7 @@ For example, depending on how you are choosing to handle your preview method, yo
 > **Unmatched values** will be replaced with an empty string.
 
 ```js
+// ./config/plugins.js
 {
   uid: 'api::page.page',
   draft: {
@@ -146,6 +146,7 @@ For example, depending on how you are choosing to handle your preview method, yo
 If you have localization enabled for a content type, the `locale` value will be included in the entry data and replaced like the rest. You can simply use `{locale}` to include it where you like in the URL or query string.
 
 ```js
+// ./config/plugins.js
 {
   uid: 'api::page.page',
   draft: {
@@ -211,6 +212,7 @@ Before granting access to the preview in your frontend app, you will want to com
 The "copy link" button located beneath the preview button can be disabled with the `copy: false` prop applied to `draft` and `published` configurations. This value is `true` by default.
 
 ```js
+// ./config/plugins.js
 {
   uid: 'api::home.home',
   published: {
@@ -220,23 +222,38 @@ The "copy link" button located beneath the preview button can be disabled with t
 }
 ```
 
-### `injectListViewColumn`
-Set to `false` to disable the preview and copy link buttons from displaying in list view. This applies to all configured content types.
+## <a id="plugin-options"></a>🔌 Plugin Options
+| property | type (default) | description |
+| - | - | - |
+| listViewColumn | boolean (`true`) | Set to `false` to disable the preview and copy link buttons from displaying in list view. |
+| openTarget | string (`StrapiPreview`) | Set to any custom string. Optionally set to `_blank` to always open the preview page in a new tab or window. Otherwise the preview will re-use the same preview tab or window. |
+
+### `listViewColumn`
+Set to `false` to disable the preview and copy link buttons from displaying in list view.
 
 ```js
-// ./config/plugins.js
-'use strict';
-
-module.exports = {
-  'preview-button': {
-    config: {
-      injectListViewColumn: false,
-      contentTypes: [
-        // etc.
-      ],
-    },
+// ./src/api/page/content-types/page/schema.js
+{
+  "kind": "collectionType",
+  "collectionName": "pages",
+  "info": {
+    "singularName": "page",
+    "pluralName": "pages",
+    "displayName": "Page",
+    "description": ""
   },
-};
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "preview-button": {
+      "listViewColumn": false
+    }
+  },
+  "attributes": {
+    // etc.
+  }
+}
 ```
 
 Ideally, the preview and copy link buttons in list view should appear alongside the other action icons for each row in the table. However, Strapi does not currently provide a hook to append new icons to that column. For now, this plugin will add its own "Preview" column with the extra icon actions.
@@ -244,28 +261,38 @@ Ideally, the preview and copy link buttons in list view should appear alongside 
 <img style="width: 960px; height: auto;" src="public/list-view.png" alt="Screenshot for list view in Strapi preview button plugin" />
 
 ### `openTarget`
-By default this value is set to `StrapiPreview`. It is used in the `window.open` function for the preview button to always open in the same tab.
+By default this value is set to `StrapiPreview` but it can be any custom string. It is used in the `window.open` function for the preview button to always open in the same tab.
 
-If you would rather disable this and, for example, have the preview button always open in a new tab, you could use `_blank` as the value. Any special target keywords such as `_blank`, `_top`, `_self`, or `_parent` are acceptable values.
+If you would rather disable this and, for example, have the preview button always open in a new tab, you could use `_blank` as the value. Special target keywords such as `_blank`, `_top`, `_self`, or `_parent` are also acceptable values.
+
+You could also use a different `openTarget` for each model schema if you wanted to have each collection type open in it's own designated tab or window.
 
 ```js
-// ./config/plugins.js
-'use strict';
-
-module.exports = {
-  'preview-button': {
-    config: {
-      openTarget: '_blank',
-      contentTypes: [
-        // etc.
-      ],
-    },
+// ./src/api/page/content-types/page/schema.js
+{
+  "kind": "collectionType",
+  "collectionName": "pages",
+  "info": {
+    "singularName": "page",
+    "pluralName": "pages",
+    "displayName": "Page",
+    "description": ""
   },
-};
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "preview-button": {
+      "openTarget": "_blank"
+    }
+  },
+  "attributes": {
+    // etc.
+  }
+}
 ```
 
 ## <a id="extending"></a>🔩 Extending
-
 If you need to apply more advanced logic to the preview URL, you can accomplish this with the `plugin/preview-button/before-build-url` hook included with this plugin.
 
 Your Strapi app will need a **custom plugin** in order to use this hook.
@@ -307,7 +334,7 @@ The `package.json` is required for a Strapi plugin.
 // ./strapi-admin.js
 'use strict';
 
-module.exports = require( './admin/src' ).default;
+module.exports = require('./admin/src').default;
 ```
 
 In the main plugin file below, we register the plugin in the `register` method and we register the hook with the `bootstrap` method.

--- a/admin/src/components/CopyLinkButton/index.js
+++ b/admin/src/components/CopyLinkButton/index.js
@@ -2,9 +2,9 @@ import React, { memo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { Button } from '@strapi/design-system';
+import { Button } from '@strapi/design-system/Button';
 import { useNotification } from '@strapi/helper-plugin';
-import { Link as LinkIcon } from '@strapi/icons';
+import LinkIcon from '@strapi/icons/Link';
 
 import { getTrad } from '../../utils';
 

--- a/admin/src/components/CopyLinkButton/index.js
+++ b/admin/src/components/CopyLinkButton/index.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
@@ -12,19 +12,18 @@ const CopyLinkButton = ({ isDraft, url }) => {
   const { formatMessage } = useIntl();
   const toggleNotification = useNotification();
 
+  const handleOnCopy = useCallback(() => {
+    toggleNotification({
+      type: 'success',
+      message: {
+        id: 'notification.success.link-copied',
+        defaultMessage: 'Link copied to the clipboard',
+      },
+    });
+  }, [toggleNotification]);
+
   return (
-    <CopyToClipboard
-      text={url}
-      onCopy={() => {
-        toggleNotification({
-          type: 'success',
-          message: {
-            id: 'notification.success.link-copied',
-            defaultMessage: 'Link copied to the clipboard',
-          },
-        });
-      }}
-    >
+    <CopyToClipboard text={url} onCopy={handleOnCopy}>
       <Button size="S" startIcon={<LinkIcon />} variant="secondary" style={{ width: '100%' }}>
         {formatMessage(
           isDraft

--- a/admin/src/components/EditViewRightLinks/index.js
+++ b/admin/src/components/EditViewRightLinks/index.js
@@ -6,13 +6,13 @@ import CopyLinkButton from '../CopyLinkButton';
 import PreviewButton from '../PreviewButton';
 
 const EditViewRightLinks = () => {
-  const { allLayoutData, hasDraftAndPublish, isCreatingEntry, modifiedData } =
+  const { allLayoutData, hasDraftAndPublish, isCreatingEntry, initialData } =
     useCMEditViewDataManager();
-  const isDraft = hasDraftAndPublish && !modifiedData?.publishedAt;
+  const isDraft = hasDraftAndPublish && !initialData?.publishedAt;
   const { uid } = allLayoutData.contentType;
   const { canCopy, isLoading, isSupported, openTarget, url } = usePreviewButton(
     uid,
-    modifiedData,
+    initialData,
     isDraft,
     isCreatingEntry
   );

--- a/admin/src/components/EditViewRightLinks/index.js
+++ b/admin/src/components/EditViewRightLinks/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useCMEditViewDataManager } from '@strapi/helper-plugin';
 
-import { usePreviewUrl } from '../../hooks';
+import { usePreviewButton } from '../../hooks';
 import CopyLinkButton from '../CopyLinkButton';
 import PreviewButton from '../PreviewButton';
 
@@ -10,7 +10,7 @@ const EditViewRightLinks = () => {
     useCMEditViewDataManager();
   const isDraft = hasDraftAndPublish && !modifiedData?.publishedAt;
   const { uid } = allLayoutData.contentType;
-  const { canCopy, isLoading, isSupported, openTarget, url } = usePreviewUrl(
+  const { canCopy, isLoading, isSupported, openTarget, url } = usePreviewButton(
     uid,
     modifiedData,
     isDraft,
@@ -20,6 +20,10 @@ const EditViewRightLinks = () => {
   if (!isSupported || isCreatingEntry || isLoading || !url) {
     return null;
   }
+
+  /**
+   * @TODO - Maybe use React.Suspense here with isLoading?
+   */
 
   return (
     <>

--- a/admin/src/components/EditViewRightLinks/index.js
+++ b/admin/src/components/EditViewRightLinks/index.js
@@ -9,9 +9,9 @@ const EditViewRightLinks = () => {
   const { allLayoutData, hasDraftAndPublish, isCreatingEntry, initialData } =
     useCMEditViewDataManager();
   const isDraft = hasDraftAndPublish && !initialData?.publishedAt;
-  const { uid } = allLayoutData.contentType;
+
   const { canCopy, isLoading, isSupported, openTarget, url } = usePreviewButton(
-    uid,
+    allLayoutData,
     initialData,
     isDraft,
     isCreatingEntry

--- a/admin/src/components/ListViewColumn/index.js
+++ b/admin/src/components/ListViewColumn/index.js
@@ -2,15 +2,20 @@ import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { Flex, IconButton } from '@strapi/design-system';
+import { Flex } from '@strapi/design-system/Flex';
+import { IconButton } from '@strapi/design-system/IconButton';
+import { Loader } from '@strapi/design-system/Loader';
 import { stopPropagation, useNotification } from '@strapi/helper-plugin';
-import { ExternalLink, Link as LinkIcon } from '@strapi/icons';
+import ExternalLink from '@strapi/icons/ExternalLink';
+import LinkIcon from '@strapi/icons/Link';
 
+import { usePreviewButton } from '../../hooks';
 import { getTrad } from '../../utils';
 
-const ListViewTableCell = ({ canCopy, isDraft, target, url }) => {
+const ListViewColumn = ({ uid, data, isDraft }) => {
   const { formatMessage } = useIntl();
   const toggleNotification = useNotification();
+  const { canCopy, isLoading, openTarget, url } = usePreviewButton(uid, data, isDraft, false);
 
   const handleClick = useCallback(
     (event) => {
@@ -19,10 +24,18 @@ const ListViewTableCell = ({ canCopy, isDraft, target, url }) => {
         return;
       }
 
-      window.open(url, target);
+      window.open(url, openTarget);
     },
-    [url, target]
+    [url, openTarget]
   );
+
+  if (isLoading) {
+    return (
+      <Flex {...stopPropagation}>
+        <Loader small={true} />
+      </Flex>
+    );
+  }
 
   return (
     <Flex {...stopPropagation}>
@@ -76,11 +89,10 @@ const ListViewTableCell = ({ canCopy, isDraft, target, url }) => {
   );
 };
 
-ListViewTableCell.propTypes = {
-  canCopy: PropTypes.bool.isRequired,
+ListViewColumn.propTypes = {
+  uid: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
   isDraft: PropTypes.bool.isRequired,
-  target: PropTypes.string.isRequired,
-  url: PropTypes.string.isRequired,
 };
 
-export default ListViewTableCell;
+export default ListViewColumn;

--- a/admin/src/components/PreviewButton/index.js
+++ b/admin/src/components/PreviewButton/index.js
@@ -1,8 +1,8 @@
 import React, { memo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import { Button } from '@strapi/design-system';
-import { ExternalLink } from '@strapi/icons';
+import { Button } from '@strapi/design-system/Button';
+import ExternalLink from '@strapi/icons/ExternalLink';
 
 import { getTrad } from '../../utils';
 

--- a/admin/src/components/index.js
+++ b/admin/src/components/index.js
@@ -1,4 +1,4 @@
 export { default as CopyLinkButton } from './CopyLinkButton';
 export { default as EditViewRightLinks } from './EditViewRightLinks';
-export { default as ListViewTableCell } from './ListViewTableCell';
+export { default as ListViewColumn } from './ListViewColumn';
 export { default as PreviewButton } from './PreviewButton';

--- a/admin/src/contentManagerHooks/add-preview-column.js
+++ b/admin/src/contentManagerHooks/add-preview-column.js
@@ -5,11 +5,8 @@ import { ListViewColumn } from '../components';
 import { pluginId } from '../utils';
 
 const addPreviewColumn = ({ displayedHeaders, layout }) => {
-  const uid = layout.contentType.uid;
-  const supportFlagKeys = ['contentType', 'pluginOptions', pluginId, 'listViewColumn'];
-  const isSupported = get(layout, supportFlagKeys, false) === true;
-  const draftAndPublishKeys = ['contentType', 'options', 'draftAndPublish'];
-  const hasDraftAndPublish = get(layout, draftAndPublishKeys, false) === true;
+  const supportKeys = ['contentType', 'pluginOptions', pluginId, 'listViewColumn'];
+  const isSupported = get(layout, supportKeys, false) === true;
 
   // Do nothing if the preview button column is not supported or disabled for this UID.
   if (!isSupported) {
@@ -33,11 +30,7 @@ const addPreviewColumn = ({ displayedHeaders, layout }) => {
           sortable: false,
         },
         name: 'preview',
-        cellFormatter: (data) => {
-          const isDraft = hasDraftAndPublish && !data?.publishedAt;
-
-          return <ListViewColumn uid={uid} data={data} isDraft={isDraft} />;
-        },
+        cellFormatter: (data) => <ListViewColumn data={data} layout={layout} />,
       },
     ],
     layout,

--- a/admin/src/contentManagerHooks/add-preview-column.js
+++ b/admin/src/contentManagerHooks/add-preview-column.js
@@ -1,15 +1,18 @@
 import React from 'react';
+import get from 'lodash/get';
 
-import ListViewTableCell from '../components/ListViewTableCell';
-import { parseUrl } from '../utils';
+import { ListViewColumn } from '../components';
+import { pluginId } from '../utils';
 
-const addPreviewColumn = ({ displayedHeaders, layout }, pluginConfig) => {
-  const { contentTypes, injectListViewColumn, openTarget } = pluginConfig;
-  const uidConfig = contentTypes?.find((type) => type.uid === layout.contentType.uid);
-  const isSupported = !!uidConfig;
+const addPreviewColumn = ({ displayedHeaders, layout }) => {
+  const uid = layout.contentType.uid;
+  const supportFlagKeys = ['contentType', 'pluginOptions', pluginId, 'listViewColumn'];
+  const isSupported = get(layout, supportFlagKeys, false) === true;
+  const draftAndPublishKeys = ['contentType', 'options', 'draftAndPublish'];
+  const hasDraftAndPublish = get(layout, draftAndPublishKeys, false) === true;
 
-  // Do nothing if this feature is not a supported type for the preview button.
-  if (!isSupported || !injectListViewColumn) {
+  // Do nothing if the preview button column is not supported or disabled for this UID.
+  if (!isSupported) {
     return {
       displayedHeaders,
       layout,
@@ -31,23 +34,9 @@ const addPreviewColumn = ({ displayedHeaders, layout }, pluginConfig) => {
         },
         name: 'preview',
         cellFormatter: (data) => {
-          const hasDraftAndPublish = layout.contentType.options.draftAndPublish === true;
-          const isDraft = hasDraftAndPublish && !data.publishedAt;
-          const configFromState = isSupported && uidConfig[isDraft ? 'draft' : 'published'];
-          const url = parseUrl(configFromState, data);
+          const isDraft = hasDraftAndPublish && !data?.publishedAt;
 
-          if (!url) {
-            return null;
-          }
-
-          return (
-            <ListViewTableCell
-              canCopy={configFromState?.copy === false ? false : true}
-              isDraft={isDraft}
-              target={openTarget}
-              url={url}
-            />
-          );
+          return <ListViewColumn uid={uid} data={data} isDraft={isDraft} />;
         },
       },
     ],

--- a/admin/src/hooks/index.js
+++ b/admin/src/hooks/index.js
@@ -1,2 +1,2 @@
 export { default as usePluginConfig } from './use-plugin-config';
-export { default as usePreviewUrl } from './use-preview-url';
+export { default as usePreviewButton } from './use-preview-button';

--- a/admin/src/hooks/use-preview-button.js
+++ b/admin/src/hooks/use-preview-button.js
@@ -1,17 +1,24 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import get from 'lodash/get';
 import { useStrapiApp } from '@strapi/helper-plugin';
 
-import { HOOK_BEFORE_BUILD_URL } from '../constants';
+import { HOOK_BEFORE_BUILD_URL, PREVIEW_WINDOW_NAME } from '../constants';
 import usePluginConfig from './use-plugin-config';
-import { parseUrl } from '../utils';
+import { parseUrl, pluginId } from '../utils';
 
-const usePreviewButton = (uid, data, isDraft, isCreating) => {
+const usePreviewButton = (layout, data, isDraft, isCreating) => {
   const { runHookWaterfall } = useStrapiApp();
   const { data: config, isLoading } = usePluginConfig();
   const [url, setUrl] = useState(null);
   const [canCopy, setCopy] = useState(true);
 
-  const openTarget = config?.openTarget;
+  const { contentType } = layout;
+  const { uid } = contentType;
+  const openTarget = get(
+    contentType,
+    ['pluginOptions', pluginId, 'openTarget'],
+    PREVIEW_WINDOW_NAME
+  );
   const uidConfig = config?.contentTypes?.find((type) => type.uid === uid);
   const isSupported = !!uidConfig;
 

--- a/admin/src/hooks/use-preview-button.js
+++ b/admin/src/hooks/use-preview-button.js
@@ -5,7 +5,7 @@ import { HOOK_BEFORE_BUILD_URL } from '../constants';
 import usePluginConfig from './use-plugin-config';
 import { parseUrl } from '../utils';
 
-const usePreviewUrl = (uid, data, isDraft, isCreating) => {
+const usePreviewButton = (uid, data, isDraft, isCreating) => {
   const { runHookWaterfall } = useStrapiApp();
   const { data: config, isLoading } = usePluginConfig();
   const [url, setUrl] = useState(null);
@@ -36,8 +36,10 @@ const usePreviewUrl = (uid, data, isDraft, isCreating) => {
       },
       true
     );
+
     const url = parseUrl(state, data);
 
+    // Do nothing if we failed to build the URL for some reason.
     if (!url) {
       return;
     }
@@ -63,4 +65,4 @@ const usePreviewUrl = (uid, data, isDraft, isCreating) => {
   };
 };
 
-export default usePreviewUrl;
+export default usePreviewButton;

--- a/admin/src/reducers/config.js
+++ b/admin/src/reducers/config.js
@@ -1,12 +1,11 @@
 import produce from 'immer';
 
-import { ACTION_RESOLVE_CONFIG, PREVIEW_WINDOW_NAME } from '../constants';
+import { ACTION_RESOLVE_CONFIG } from '../constants';
 
 const initialState = {
   isLoading: true,
   config: {
     contentTypes: [],
-    openTarget: PREVIEW_WINDOW_NAME,
   },
 };
 

--- a/admin/src/reducers/config.js
+++ b/admin/src/reducers/config.js
@@ -6,7 +6,6 @@ const initialState = {
   isLoading: true,
   config: {
     contentTypes: [],
-    injectListViewColumn: false,
     openTarget: PREVIEW_WINDOW_NAME,
   },
 };

--- a/server/config.js
+++ b/server/config.js
@@ -3,12 +3,9 @@
 const { ValidationError } = require('@strapi/utils').errors;
 const has = require('lodash/has');
 
-const { PREVIEW_WINDOW_NAME } = require('./constants');
-
 module.exports = {
   default: {
     contentTypes: [],
-    openTarget: PREVIEW_WINDOW_NAME,
   },
   validator: (config) => {
     if (!has(config, 'contentTypes')) {

--- a/server/config.js
+++ b/server/config.js
@@ -8,7 +8,6 @@ const { PREVIEW_WINDOW_NAME } = require('./constants');
 module.exports = {
   default: {
     contentTypes: [],
-    injectListViewColumn: true,
     openTarget: PREVIEW_WINDOW_NAME,
   },
   validator: (config) => {

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  PREVIEW_WINDOW_NAME: 'StrapiPreview',
-};


### PR DESCRIPTION
This PR applies some frontend optimizations and includes a breaking changes to the plugin configuration.

The `injectListColumnView` config option is no longer part of the top-level plugin config. It is now applied to the model schema's `pluginOptions` prop.

The list view column hook is now much simpler and no longer fails to render after first logging in 🙌🏻 