### PR TITLE
Fix param encoding in parseUrl util

### DIFF
--- a/admin/src/utils/__tests__/parse-url.spec.js
+++ b/admin/src/utils/__tests__/parse-url.spec.js
@@ -33,6 +33,42 @@ describe('parseUrl', () => {
     expect(result).toEqual(output);
   });
 
+  it('should encode query string params', () => {
+    const config = {
+      url: 'https://www.example.com/{slug}',
+      query: {
+        type: 'page',
+        foobar: '{foobar}',
+      },
+    };
+    const data = {
+      slug: 'test',
+      foobar: 'foo/bar/test',
+    };
+    const output = 'https://www.example.com/test?type=page&foobar=foo%2Fbar%2Ftest';
+    const result = parseUrl(config, data, true);
+
+    expect(result).toEqual(output);
+  });
+
+  it('should not double-encode query string params', () => {
+    const config = {
+      url: 'https://www.example.com/{slug}',
+      query: {
+        type: 'page',
+        foobar: '{foobar}',
+      },
+    };
+    const data = {
+      slug: 'test',
+      foobar: 'foo%2Fbar%2Ftest',
+    };
+    const output = 'https://www.example.com/test?type=page&foobar=foo%2Fbar%2Ftest';
+    const result = parseUrl(config, data, true);
+
+    expect(result).toEqual(output);
+  });
+
   it('should return null if params are null', () => {
     const result = parseUrl(null, null);
 

--- a/admin/src/utils/parse-url.js
+++ b/admin/src/utils/parse-url.js
@@ -14,9 +14,10 @@ const parseUrl = (config, data) => {
       return acc;
     }
 
+    // We are decoding and encoding at the same time here to avoid double-encoding.
     return {
       ...acc,
-      [key]: val,
+      [key]: encodeURIComponent(decodeURIComponent(val)),
     };
   }, {});
   const params = Object.entries(config?.query ?? {}).reduce((acc, [key, val]) => {
@@ -27,7 +28,16 @@ const parseUrl = (config, data) => {
   }, {});
 
   const url = interpolate(trimSlashes(config.url), replacements);
-  const query = qs.stringify(params, { addQueryPrefix: true });
+  const query = qs.stringify(params, {
+    addQueryPrefix: true,
+
+    /**
+     * @NOTE - Disabling the `encoding` option here because we are already
+     * handling it in `replacements` and for some reason, tests are failing
+     * because qs mistakenly double-encodes params, but only during tests.
+     */
+    encode: false,
+  });
 
   return `${url}${query}`;
 };


### PR DESCRIPTION
Previously the plugin was relying on `qs` to automatically encode query string params but once tests related to encoded params were added, the tests were failing.

The fix for this was to disable encoding in `qs` and instead use `encodeURIComponent` directly in the plugin.