### PR TITLE
Switch from `useCMEditViewDataManager()` to `useDocument()`

### DIFF
--- a/admin/src/components/ListViewColumn/index.tsx
+++ b/admin/src/components/ListViewColumn/index.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo } from 'react';
-import { useIntl } from 'react-intl';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
-import get from 'lodash/get';
 import { Flex, IconButton, Loader } from '@strapi/design-system';
 import { ExternalLink, Link as LinkIcon } from '@strapi/icons';
+import { UID } from '@strapi/strapi';
 import { useNotification } from '@strapi/strapi/admin';
+import get from 'lodash/get';
+import { useCallback, useMemo } from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { useIntl } from 'react-intl';
 
 import { PREVIEW_WINDOW_NAME } from '../../constants';
 import { usePreviewButton } from '../../hooks';
@@ -14,7 +15,7 @@ export interface ListViewColumnProps {
   data: any;
   layout: {
     contentType: {
-      uid: string;
+      uid: UID.ContentType | undefined;
       options: {
         draftAndPublish: boolean;
       };

--- a/admin/src/components/ListViewColumn/index.tsx
+++ b/admin/src/components/ListViewColumn/index.tsx
@@ -35,7 +35,7 @@ const ListViewColumn = ({ data, layout }: ListViewColumnProps) => {
   const hasDraftAndPublish = layout.contentType.options.draftAndPublish === true;
   const isDraft = hasDraftAndPublish && !data?.publishedAt;
 
-  const { isLoading, draft, published } = usePreviewButton(layout, data, false);
+  const { isLoading, draft, published } = usePreviewButton(layout.contentType.uid, data);
 
   const config = useMemo(() => {
     if (isDraft) {

--- a/admin/src/components/PreviewButton/index.tsx
+++ b/admin/src/components/PreviewButton/index.tsx
@@ -17,7 +17,9 @@ const PreviewButton = ({ isDraft, openTarget, url }: PreviewButtonProps) => {
     (event: Event) => {
       event.preventDefault();
 
-      if (!url)  return;
+      if (!url) {
+        return
+      };
 
       window.open(url, openTarget);
     },
@@ -27,7 +29,7 @@ const PreviewButton = ({ isDraft, openTarget, url }: PreviewButtonProps) => {
   return (
     <LinkButton
       href={url}
-      target={'_blank'}
+      target="_blank"
       onClick={handleClick}
       size="S"
       startIcon={<ExternalLink />}

--- a/admin/src/components/PreviewButton/index.tsx
+++ b/admin/src/components/PreviewButton/index.tsx
@@ -1,7 +1,7 @@
+import { LinkButton } from '@strapi/design-system';
+import { ExternalLink } from '@strapi/icons';
 import { memo, useCallback } from 'react';
 import { useIntl } from 'react-intl';
-import { Button } from '@strapi/design-system';
-import { ExternalLink } from '@strapi/icons';
 
 import { type PreviewButtonStateConfig } from '../../../../server/src/config';
 import { getTrad } from '../../utils';
@@ -15,11 +15,9 @@ const PreviewButton = ({ isDraft, openTarget, url }: PreviewButtonProps) => {
 
   const handleClick = useCallback(
     (event: Event) => {
-      if (!url) {
-        event.preventDefault();
+      event.preventDefault();
 
-        return;
-      }
+      if (!url)  return;
 
       window.open(url, openTarget);
     },
@@ -27,12 +25,15 @@ const PreviewButton = ({ isDraft, openTarget, url }: PreviewButtonProps) => {
   );
 
   return (
-    <Button
+    <LinkButton
+      href={url}
+      target={'_blank'}
       onClick={handleClick}
       size="S"
       startIcon={<ExternalLink />}
       variant="secondary"
       style={{ width: '100%' }}
+      disabled={!url}
     >
       {formatMessage(
         isDraft
@@ -45,7 +46,7 @@ const PreviewButton = ({ isDraft, openTarget, url }: PreviewButtonProps) => {
               defaultMessage: 'Open live view',
             }
       )}
-    </Button>
+    </LinkButton>
   );
 };
 

--- a/admin/src/contentManagerHooks/addPreviewColumn.tsx
+++ b/admin/src/contentManagerHooks/addPreviewColumn.tsx
@@ -1,3 +1,4 @@
+import { UID } from '@strapi/strapi';
 import get from 'lodash/get';
 
 import { ListViewColumn } from '../components';
@@ -19,7 +20,7 @@ export interface AddPreviewColumnProps {
   }[];
   layout: {
     contentType: {
-      uid: string;
+      uid: UID.ContentType | undefined;
       options: {
         draftAndPublish: boolean;
       };

--- a/admin/src/hooks/usePreviewButton.ts
+++ b/admin/src/hooks/usePreviewButton.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from 'react';
 import { useStrapiApp } from '@strapi/admin/strapi-admin';
+import { useCallback, useEffect, useState } from 'react';
 
+import { type UID } from '@strapi/strapi';
 import { type PreviewButtonStateConfig } from '../../../server/src/config';
 import { HOOK_BEFORE_BUILD_URL } from '../constants';
 import { getPublishStateConfig } from '../utils';
@@ -14,9 +15,8 @@ export interface UsePreviewButtonReturn {
 }
 
 const usePreviewButton = (
-  layout: any,
+  uid: UID.ContentType | undefined,
   data: any,
-  isCreating: boolean,
 ): UsePreviewButtonReturn => {
   const runHookWaterfall = useStrapiApp('PreviewButton', (value) => value.runHookWaterfall);
   const { data: config, isLoading } = usePluginConfig();
@@ -24,7 +24,6 @@ const usePreviewButton = (
   const [draft, setDraft] = useState<PreviewButtonStateConfig | null>(null);
   const [published, setPublished] = useState<PreviewButtonStateConfig | null>(null);
 
-  const { uid } = layout.contentType;
   const uidConfig = config?.contentTypes?.find((type) => type.uid === uid);
   const isSupported = !!uidConfig;
 
@@ -47,12 +46,12 @@ const usePreviewButton = (
   }, [data, uidConfig, setDraft, setPublished, runHookWaterfall]);
 
   useEffect(() => {
-    if (!isSupported || isLoading || isCreating) {
+    if (!isSupported || isLoading) {
       return;
     }
 
     compileWithHooks();
-  }, [isSupported, isLoading, isCreating, compileWithHooks]);
+  }, [isSupported, isLoading, compileWithHooks]);
 
   return {
     isLoading,

--- a/package.json
+++ b/package.json
@@ -74,14 +74,16 @@
     "qs": "6.12.0",
     "react-copy-to-clipboard": "5.1.0",
     "react-intl": "6.6.2",
-    "react-redux": "8.1.3"
+    "react-redux": "8.1.3",
+    "styled-components": "^6.1.13"
   },
   "peerDependencies": {
     "@strapi/sdk-plugin": "^5.2.0",
     "@strapi/strapi": "^5.0.0-rc.22",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.1"
+    "react-router-dom": "^6.26.1",
+    "styled-components": "^6.1.13"
   },
   "devDependencies": {
     "@babel/core": "7.24.3",

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,3 +1,4 @@
+import { type UID } from '@strapi/strapi';
 import { errors } from '@strapi/utils';
 import has from 'lodash/has';
 
@@ -11,7 +12,7 @@ export interface PreviewButtonStateConfig {
 
 export interface PreviewButtonPluginConfig {
   contentTypes?: {
-    uid: any;
+    uid: UID.ContentType;
     draft?: PreviewButtonStateConfig;
     published?: PreviewButtonStateConfig;
   }[] | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,6 +688,13 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.1.tgz#4ffb0055f7ef676ebc3a5a91fb621393294e2f43"
   integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
 
+"@emotion/is-prop-valid@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz#d4175076679c6a26faa92b03bb786f9e52612337"
+  integrity sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==
+  dependencies:
+    "@emotion/memoize" "^0.8.1"
+
 "@emotion/memoize@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.8.1.tgz#c1ddb040429c6d21d38cc945fe75c818cfb68e17"
@@ -723,7 +730,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.2.2.tgz#d58e788ee27267a14342303e1abb3d508b6d0fec"
   integrity sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==
 
-"@emotion/unitless@^0.8.1":
+"@emotion/unitless@0.8.1", "@emotion/unitless@^0.8.1":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
   integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
@@ -3971,6 +3978,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.2.tgz#01284dde9ef4e6d8cef6422798d9a3ad18a66f8b"
   integrity sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==
 
+"@types/stylis@4.2.5":
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.5.tgz#1daa6456f40959d06157698a653a9ab0a70281df"
+  integrity sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==
+
 "@types/through@*":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.32.tgz#1c4c8a29140221c1b29c2874dea1f4a1f2092c6a"
@@ -5075,6 +5087,11 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
+camelize@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.1.tgz#89b7e16884056331a35d6b5ad064332c91daa6c3"
+  integrity sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==
+
 caniuse-lite@^1.0.30001541:
   version "1.0.30001561"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001561.tgz#752f21f56f96f1b1a52e97aae98c57c562d5d9da"
@@ -5712,6 +5729,11 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==
+
 css-loader@^6.10.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.11.0.tgz#33bae3bf6363d0a7c2cf9031c96c744ff54d85ba"
@@ -5737,6 +5759,15 @@ css-select@^4.1.3:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
+css-to-react-native@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.2.0.tgz#cdd8099f71024e149e4f6fe17a7d46ecd55f1e32"
+  integrity sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
+
 css-what@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
@@ -5746,6 +5777,11 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
+
+csstype@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
 csstype@^3.0.2:
   version "3.1.2"
@@ -11330,10 +11366,19 @@ postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
+postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
+
+postcss@8.4.38, postcss@^8.4.33, postcss@^8.4.35:
+  version "8.4.38"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
+  integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.0.0"
+    source-map-js "^1.2.0"
 
 postcss@^8.3.11:
   version "8.4.31"
@@ -11343,15 +11388,6 @@ postcss@^8.3.11:
     nanoid "^3.3.6"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
-
-postcss@^8.4.33, postcss@^8.4.35:
-  version "8.4.38"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
-  integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
-  dependencies:
-    nanoid "^3.3.7"
-    picocolors "^1.0.0"
-    source-map-js "^1.2.0"
 
 postcss@^8.4.38:
   version "8.4.45"
@@ -12476,6 +12512,11 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+shallowequal@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 sharp@0.32.6:
   version "0.32.6"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.32.6.tgz#6ad30c0b7cd910df65d5f355f774aa4fce45732a"
@@ -13119,10 +13160,30 @@ style-mod@^4.0.0, style-mod@^4.1.0:
   resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.1.0.tgz#a313a14f4ae8bb4d52878c0053c4327fb787ec09"
   integrity sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==
 
+styled-components@^6.1.13:
+  version "6.1.13"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.1.13.tgz#2d777750b773b31469bd79df754a32479e9f475e"
+  integrity sha512-M0+N2xSnAtwcVAQeFEsGWFFxXDftHUD7XrKla06QbpUMmbmtFBMMTcKWvFXtWxuD5qQkB8iU5gk6QASlx2ZRMw==
+  dependencies:
+    "@emotion/is-prop-valid" "1.2.2"
+    "@emotion/unitless" "0.8.1"
+    "@types/stylis" "4.2.5"
+    css-to-react-native "3.2.0"
+    csstype "3.1.3"
+    postcss "8.4.38"
+    shallowequal "1.1.0"
+    stylis "4.3.2"
+    tslib "2.6.2"
+
 stylis@4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.2.0.tgz#79daee0208964c8fe695a42fcffcac633a211a51"
   integrity sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==
+
+stylis@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.2.tgz#8f76b70777dd53eb669c6f58c997bf0a9972e444"
+  integrity sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -13441,15 +13502,15 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@2.6.2, tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsscmp@1.0.6:
   version "1.0.6"


### PR DESCRIPTION
This PR finishes replacing usage of @strapi/helper-plugin. ([@strapi/helper-plugin is deprecated and is not compatible](https://docs-next.strapi.io/dev-docs/migration/v4-to-v5/breaking-changes/helper-plugin-deprecated) with Strapi 5.) It builds on builds on #133. `useCMEditViewDataManager()` from @strapi/helper-plugin has no direct replacement, but the part used by this plugin is replaced by `useDocument()` from `@strapi/admin/strapi-admin`.

This PR also switches the `<Button />` component usage to `<LinkButton />`.  They look the same, but they allow right clicking to copy links and middle clicking to open in a new tab. If you click them, they behave exactly as the always have; `event.preventDefault()` is called and the regular logic takes over.