### PR TITLE
Fix create entry view

### DIFF
--- a/admin/src/components/EditViewRightLinks/index.tsx
+++ b/admin/src/components/EditViewRightLinks/index.tsx
@@ -6,6 +6,11 @@ import PreviewButtonGroup from '../PreviewButtonGroup';
 
 const EditViewRightLinks = () => {
   const { collectionType = '', id: documentId, slug: model = '' } = useParams();
+
+  if (!documentId || documentId === 'create') {
+    return null;
+  }
+
   const [searchParams] = useSearchParams();
   const params: Record<string, string> = {};
   const locale = searchParams.get('plugins[i18n][locale]');

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -27,7 +27,7 @@ export const defaultConfig: PreviewButtonPluginConfig = {
 export default {
   default: defaultConfig,
   validator(config: PreviewButtonPluginConfig) {
-    if (!has(config, 'contentTypes')) {
+    if (!has(config, 'contentTypes') || config.contentTypes === null) {
       return;
     }
 


### PR DESCRIPTION
On the **create entry view** where the preview button is enabled, calling `useDocument` with `documentId = 'create'` logs out the user.

This PR provides a fix where the component aborts rendering if the `documentId === 'create'`.