### PR TITLE
Release v3.0.1

### DIFF
--- a/admin/src/components/EditViewRightLinks/index.tsx
+++ b/admin/src/components/EditViewRightLinks/index.tsx
@@ -6,6 +6,11 @@ import PreviewButtonGroup from '../PreviewButtonGroup';
 
 const EditViewRightLinks = () => {
   const { collectionType = '', id: documentId, slug: model = '' } = useParams();
+
+  if (!documentId || documentId === 'create') {
+    return null;
+  }
+
   const [searchParams] = useSearchParams();
   const params: Record<string, string> = {};
   const locale = searchParams.get('plugins[i18n][locale]');

--- a/admin/src/translations/es.json
+++ b/admin/src/translations/es.json
@@ -1,7 +1,7 @@
 {
   "form.button.draft": "Abrir vista previa",
   "form.button.published": "Abrir vista en vivo",
-  "form.button.copy-link": "Copiar link",
+  "form.button.copy-link": "Copiar enlace",
   "form.button.copy-link.draft": "Copiar enlace de vista previa",
   "list-view.column-header": "Avance",
   "notification.success.link-copied": "Enlace copiado al portapapeles"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-preview-button",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A plugin for Strapi CMS that adds a preview button and live view button to the content manager edit view.",
   "license": "MIT",
   "strapi": {

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -27,7 +27,7 @@ export const defaultConfig: PreviewButtonPluginConfig = {
 export default {
   default: defaultConfig,
   validator(config: PreviewButtonPluginConfig) {
-    if (!has(config, 'contentTypes')) {
+    if (!has(config, 'contentTypes') || config.contentTypes === null) {
       return;
     }
 


### PR DESCRIPTION
# Included in this release

### 🐛 Bug fixes
* In `EditViewRightLinks`, check for `documentId === 'create'`, otherwise the user is mysteriously logged out on the create entry view.
* Fix overlooked Spanish translation.