### PR TITLE
Fix bug with single types on edit view

### DIFF
--- a/admin/src/components/EditViewRightLinks/index.tsx
+++ b/admin/src/components/EditViewRightLinks/index.tsx
@@ -6,8 +6,9 @@ import PreviewButtonGroup from '../PreviewButtonGroup';
 
 const EditViewRightLinks = () => {
   const { collectionType = '', id: documentId, slug: model = '' } = useParams();
+  const isSingleType = collectionType === 'single-types';
 
-  if (!documentId || documentId === 'create') {
+  if ((!isSingleType && !documentId) || documentId === 'create') {
     return null;
   }
 

--- a/admin/src/hooks/usePreviewButton.ts
+++ b/admin/src/hooks/usePreviewButton.ts
@@ -55,12 +55,12 @@ const usePreviewButton = (uid: UID.ContentType | undefined, data: any): UsePrevi
   }, [data, uidConfig, setDraft, setPublished, runHookWaterfall]);
 
   useEffect(() => {
-    if (!isSupported || isLoading) {
+    if (isLoading || !isSupported) {
       return;
     }
 
     compileWithHooks();
-  }, [isSupported, isLoading, compileWithHooks]);
+  }, [isLoading, isSupported, compileWithHooks]);
 
   return {
     isLoading,


### PR DESCRIPTION
This PR fixes a bug with single types which was completely skipping the preview button without checking against single type editing.